### PR TITLE
change low activity message

### DIFF
--- a/src/components/evaluations/info/common/FeedbackPm.vue
+++ b/src/components/evaluations/info/common/FeedbackPm.vue
@@ -91,7 +91,7 @@ export default {
 
                     // low activity warning
                     } else if (this.lowActivityWarning) {
-                        line += `the NAT have noticed that your nomination activity is too low to reach a conclusion`;
+                        line += `the NAT have noticed that your nomination activity is currently too low`;
 
                         messages.push(line);
                         messages.push(`your BN activity will be evaluated again 1 month from now!`);


### PR DESCRIPTION
Current one implies we have no conclusion, when the conclusion is their activity is too low