### PR TITLE
re-add evals to trial nat navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -99,6 +99,22 @@
                                     </router-link>
                                 </div>
                             </li>
+
+                            <!-- Trial NAT -->
+
+                            <li v-if="loggedInUser.isTrialNat" class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">
+                                    Evaluations
+                                </a>
+                                <div class="dropdown-menu">
+                                    <router-link class="dropdown-item" to="/appeval">
+                                        Applications
+                                    </router-link>
+                                    <router-link class="dropdown-item" to="/bneval">
+                                        Current BNs
+                                    </router-link>
+                                </div>
+                            </li>
                         </template>
 
                         <!-- NAT -->


### PR DESCRIPTION
was working on sth and noticed that the evals dropdown got nuked from trial nat after the latest navbar adjustment