### PR TITLE
add review button to group evals

### DIFF
--- a/helpers/discord.js
+++ b/helpers/discord.js
@@ -252,7 +252,7 @@ const webhookColors = {
     darkBlue: 1911891,        // setCooldown
     blue: 6786559,            // setFeedback
 
-    lightPurple: 11173873,    // submitVetoMediation
+    lightPurple: 11173873,    // submitVetoMediation, toggleIsReviewed
     darkPurple: 4263999,      // submitVeto
     purple: 8536232,          // startVetoMediation, concludeVetoMediation
 

--- a/models/evaluations/base.js
+++ b/models/evaluations/base.js
@@ -4,6 +4,7 @@ const baseSchema = {
     reviews: [{ type: 'ObjectId', ref: 'Review' }],
     active: { type: Boolean, default: true },
     discussion: { type: Boolean, default: false },
+    isReviewed: { type: Boolean, default: false },
     feedback: { type: String },
     cooldownDate: { type: Date },
     natEvaluators: [{ type: 'ObjectId', ref: 'User' }],

--- a/models/interfaces/evaluations.ts
+++ b/models/interfaces/evaluations.ts
@@ -19,6 +19,7 @@ interface IEvaluationBase {
     isApplication?: boolean;
     isBnEvaluation?: boolean;
     isResignation?: boolean;
+    isReviewed?: boolean;
     natEvaluatorHistory: {
         date: Date;
         user: IUserDocument;

--- a/routes/evaluations/appEval.js
+++ b/routes/evaluations/appEval.js
@@ -602,10 +602,14 @@ router.post('/toggleIsReviewed/:id', middlewares.isNat, async (req, res) => {
     app.isReviewed = !app.isReviewed;
     await app.save();
 
-    res.json({
-        isReviewed: app.isReviewed,
-        success: `Toggled evaluation review status. Refresh to see changes`,
-    });
+    res.json(app);
+
+    discord.webhookPost([{
+        author: discord.defaultWebhookAuthor(req.session),
+        color: discord.webhookColors.lightPurple,
+        description: `${app.isReviewed ? 'Reviewed feedback for ' : 'Unmarked feedback as reviewed for '} [**${app.user.username}**'s BN app](http://bn.mappersguild.com/appeval?id=${app.id})`,
+    }],
+    app.mode);
 
     Logger.generate(
         req.session.mongoId,

--- a/routes/evaluations/appEval.js
+++ b/routes/evaluations/appEval.js
@@ -593,4 +593,26 @@ router.post('/overwriteEvaluationDate/:id/', middlewares.isNat, async (req, res)
     );
 });
 
+/* POST toggle isReviewed for evaluations */
+router.post('/toggleIsReviewed/:id', middlewares.isNat, async (req, res) => {
+    const app = await AppEvaluation
+        .findById(req.params.id)
+        .populate(defaultPopulate);
+        
+    app.isReviewed = !app.isReviewed;
+    await app.save();
+
+    res.json({
+        isReviewed: app.isReviewed,
+        success: `Toggled evaluation review status. Refresh to see changes`,
+    });
+
+    Logger.generate(
+        req.session.mongoId,
+        `Toggled "${app.user.username}" ${app.mode} BN app isReviewed to ${app.isReviewed}`,
+        'appEvaluation',
+        app._id
+    );
+});
+
 module.exports = router;

--- a/routes/evaluations/bnEval.js
+++ b/routes/evaluations/bnEval.js
@@ -958,4 +958,26 @@ router.post('/overwriteEvaluationDate/:id/', middlewares.isNat, async (req, res)
     );
 });
 
+/* POST toggle isReviewed for evaluations */
+router.post('/toggleIsReviewed/:id', middlewares.isNat, async (req, res) => {
+    const er = await BnEvaluation
+        .findById(req.params.id)
+        .populate(defaultPopulate);
+
+    er.isReviewed = !er.isReviewed;
+    await er.save();
+
+    res.json({
+        isReviewed: er.isReviewed,
+        success: `Toggled evaluation review status. Refresh to see changes`,
+    });
+
+    Logger.generate(
+        req.session.mongoId,
+        `Toggled "${er.user.username}" ${er.mode} current BN evaluation isReviewed to ${er.isReviewed}`,
+        'bnEvaluation',
+        er._id
+    );
+});
+
 module.exports = { router, getGeneralEvents };

--- a/routes/evaluations/bnEval.js
+++ b/routes/evaluations/bnEval.js
@@ -967,10 +967,14 @@ router.post('/toggleIsReviewed/:id', middlewares.isNat, async (req, res) => {
     er.isReviewed = !er.isReviewed;
     await er.save();
 
-    res.json({
-        isReviewed: er.isReviewed,
-        success: `Toggled evaluation review status. Refresh to see changes`,
-    });
+    res.json(er);
+
+    discord.webhookPost([{
+        author: discord.defaultWebhookAuthor(req.session),
+        color: discord.webhookColors.lightPurple,
+        description: `${er.isReviewed ? 'Reviewed feedback for ' : 'Unmarked feedback as reviewed for '} [**${er.user.username}**'s current BN eval](http://bn.mappersguild.com/appeval?id=${er.id})`,
+    }],
+    er.mode);
 
     Logger.generate(
         req.session.mongoId,

--- a/src/components/evaluations/info/DiscussionInfo.vue
+++ b/src/components/evaluations/info/DiscussionInfo.vue
@@ -17,7 +17,7 @@
                         loggedInUser.isNat
                     "
                 />
-                <evaluation-is-reviewed/>
+                <evaluation-is-reviewed v-if="selectedEvaluation.feedback"/>
                 <feedback-info v-if="selectedEvaluation.consensus" />
             </div>
         </template>

--- a/src/components/evaluations/info/DiscussionInfo.vue
+++ b/src/components/evaluations/info/DiscussionInfo.vue
@@ -17,6 +17,7 @@
                         loggedInUser.isNat
                     "
                 />
+                <evaluation-is-reviewed/>
                 <feedback-info v-if="selectedEvaluation.consensus" />
             </div>
         </template>
@@ -43,6 +44,7 @@ import ReviewsListing from './common/ReviewsListing.vue';
 import FeedbackInfo from './common/FeedbackInfo.vue';
 import evaluations from '../../../mixins/evaluations.js';
 import NextEvaluationEstimate from './common/NextEvaluationEstimate.vue';
+import EvaluationIsReviewed from './common/EvaluationIsReviewed.vue';
 
 export default {
     name: 'DiscussionInfo',
@@ -52,6 +54,7 @@ export default {
         ReviewsListing,
         FeedbackInfo,
         NextEvaluationEstimate,
+        EvaluationIsReviewed,
     },
     mixins: [evaluations],
     computed: {

--- a/src/components/evaluations/info/common/EvaluationIsReviewed.vue
+++ b/src/components/evaluations/info/common/EvaluationIsReviewed.vue
@@ -30,7 +30,15 @@ export default {
     },
     methods: {
         async toggleEvaluationIsReviewed(e) {
-            await this.$http.executePost(`/${this.selectedEvaluation.isApplication ? 'appEval' : 'bnEval'}/toggleIsReviewed/${this.selectedEvaluation.id}`, e);   
+            const result = await this.$http.executePost(`/${this.selectedEvaluation.isApplication ? 'appEval' : 'bnEval'}/toggleIsReviewed/${this.selectedEvaluation.id}`, e); 
+            
+            if (result && !result.error) {
+                this.$store.commit('evaluations/updateEvaluation', result);
+                this.$store.dispatch('updateToastMessages', {
+                    message: `Toggled feedback sanity check`,
+                    type: 'success',
+                });
+            }  
         },
     },
 }

--- a/src/components/evaluations/info/common/EvaluationIsReviewed.vue
+++ b/src/components/evaluations/info/common/EvaluationIsReviewed.vue
@@ -1,0 +1,38 @@
+<template>
+    <div>
+        <p>
+            <b>Reviewed: </b>
+            <a
+                href="#"
+
+                data-toggle="tooltip"
+                data-placement="right"
+                title="mark evaluation as reviewed"
+                @click.prevent="toggleEvaluationIsReviewed($event)"
+            >
+                <font-awesome-icon
+                    icon="fa-solid fa-circle-check"
+                    :class="selectedEvaluation.isReviewed ? 'text-success' : 'text-secondary'"
+                />
+            </a>
+        </p>
+    </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+import evaluations from '../../../../mixins/evaluations.js';
+
+export default {
+    name: 'EvaluationIsReviewed',
+    mixins: [evaluations],
+    computed: {
+        ...mapGetters('evaluations', ['selectedEvaluation']),
+    },
+    methods: {
+        async toggleEvaluationIsReviewed(e) {
+            await this.$http.executePost(`/${this.selectedEvaluation.isApplication ? 'appEval' : 'bnEval'}/toggleIsReviewed/${this.selectedEvaluation.id}`, e);   
+        },
+    },
+}
+</script>

--- a/src/components/evaluations/info/common/EvaluationIsReviewed.vue
+++ b/src/components/evaluations/info/common/EvaluationIsReviewed.vue
@@ -4,7 +4,6 @@
             <b>Reviewed: </b>
             <a
                 href="#"
-
                 data-toggle="tooltip"
                 data-placement="right"
                 title="mark evaluation as reviewed"


### PR DESCRIPTION
makes it easier to track evals that were sanity checked by nat during bn evalers, also in regular workflow
visible to nat and bn evalers but only usable by nat btw since they're the ones doing the sanity checks

![image](https://user-images.githubusercontent.com/62819481/211323151-b6b7362b-4984-485a-bf2b-5d7312b79cda.png)
