### PR TITLE
make nat eval activity more visible

### DIFF
--- a/routes/evaluations/bnEval.js
+++ b/routes/evaluations/bnEval.js
@@ -863,7 +863,7 @@ router.get('/activity', async (req, res) => {
                 bnEvaluators: { $ne: mongoId },
             })
             .populate(applicationPopulate)
-            .sort({ createdAt: 1 }),
+            .sort({ deadline: 1 }),
 
         Evaluation
             .find({
@@ -872,7 +872,7 @@ router.get('/activity', async (req, res) => {
                 active: false,
             })
             .populate(defaultPopulate)
-            .sort({ createdAt: 1 }),
+            .sort({ deadline: 1 }),
     ]);
 
     // extract apps that user evaluated or was assigned to

--- a/src/components/evaluations/info/currentBns/userActivity/EvaluationList.vue
+++ b/src/components/evaluations/info/currentBns/userActivity/EvaluationList.vue
@@ -15,7 +15,7 @@
                 >
                     <tr v-for="event in events" :key="event.id">
                         <td class="text-nowrap">
-                            {{ findDate(event) }}
+                            {{ new Date(event.deadline).toString().slice(4, 10) }}
                         </td>
                         <td>
                             <a
@@ -27,7 +27,7 @@
                                 "
                                 target="_blank"
                             >
-                                {{ findUsername(event) }}
+                                {{ event.user.username }}
                             </a>
                         </td>
                         <td>
@@ -87,16 +87,6 @@ export default {
         ...mapState(['loggedInUser']),
     },
     methods: {
-        findDate(event) {
-            let date;
-            if (this.isApplication) date = event.createdAt;
-            else date = event.deadline;
-
-            return new Date(date).toString().slice(4, 10);
-        },
-        findUsername(event) {
-            return event.user.username;
-        },
         findVote(reviews) {
             let vote;
 

--- a/src/components/evaluations/info/currentBns/userActivity/EvaluationList.vue
+++ b/src/components/evaluations/info/currentBns/userActivity/EvaluationList.vue
@@ -4,48 +4,50 @@
             <a :href="events && `#${eventsId}`" data-toggle="collapse"
                 >{{ header }} <i class="fas fa-angle-down"
             /></a>
-            ({{ isLoading ? '...' : events ? events.length : '0' }})
+            ({{ isLoading ? '...' : events ? events.filter(e => findVote(e.reviews).toUpperCase() !== 'NONE').length : '0' }})
         </div>
 
-        <div v-if="events" :id="eventsId" class="collapse">
-            <data-table
-                v-if="events.length"
-                :headers="['Date', 'Evaluation', 'Vote', 'Consensus']"
-            >
-                <tr v-for="event in events" :key="event.id">
-                    <td class="text-nowrap">
-                        {{ findDate(event) }}
-                    </td>
-                    <td>
-                        <a
-                            :href="
-                                '/' +
-                                (isApplication ? 'appeval' : 'bneval') +
-                                '?id=' +
-                                event.id
-                            "
-                            target="_blank"
-                        >
-                            {{ findUsername(event) }}
-                        </a>
-                    </td>
-                    <td>
-                        <span :class="'text-' + findVote(event.reviews)">
-                            {{ findVote(event.reviews).toUpperCase() }}
-                        </span>
-                    </td>
-                    <td>
-                        <span :class="'text-' + event.consensus">
-                            {{
-                                event.consensus
-                                    ? event.consensus.toUpperCase()
-                                    : 'NONE'
-                            }}
-                        </span>
-                    </td>
-                </tr>
-            </data-table>
-            <p v-else class="small ml-4">None...</p>
+        <div v-if="loggedInUser.isNat">
+            <div v-if="events" :id="eventsId" class="collapse">
+                <data-table
+                    v-if="events.length"
+                    :headers="['Date', 'Evaluation', 'Vote', 'Consensus']"
+                >
+                    <tr v-for="event in events" :key="event.id">
+                        <td class="text-nowrap">
+                            {{ findDate(event) }}
+                        </td>
+                        <td>
+                            <a
+                                :href="
+                                    '/' +
+                                    (isApplication ? 'appeval' : 'bneval') +
+                                    '?id=' +
+                                    event.id
+                                "
+                                target="_blank"
+                            >
+                                {{ findUsername(event) }}
+                            </a>
+                        </td>
+                        <td>
+                            <span :class="'text-' + findVote(event.reviews)">
+                                {{ findVote(event.reviews).toUpperCase() }}
+                            </span>
+                        </td>
+                        <td>
+                            <span :class="'text-' + event.consensus">
+                                {{
+                                    event.consensus
+                                        ? event.consensus.toUpperCase()
+                                        : 'NONE'
+                                }}
+                            </span>
+                        </td>
+                    </tr>
+                </data-table>
+                <p v-else class="small ml-4">None...</p>
+            </div>
         </div>
     </div>
 </template>
@@ -80,7 +82,10 @@ export default {
         },
         isApplication: Boolean,
     },
-    computed: mapState('activity', ['isLoading']),
+    computed: {
+        ...mapState('activity', ['isLoading']), 
+        ...mapState(['loggedInUser']),
+    },
     methods: {
         findDate(event) {
             let date;

--- a/src/components/evaluations/info/currentBns/userActivity/PublicEvaluationList.vue
+++ b/src/components/evaluations/info/currentBns/userActivity/PublicEvaluationList.vue
@@ -1,0 +1,69 @@
+<template>
+    <div>
+        <div class="ml-2">
+            <a :href="events && `#${eventsId}`" data-toggle="collapse"
+                >{{ header }} <i class="fas fa-angle-down"
+            /></a>
+            ({{ isLoading ? '...' : events ? events.length : '0' }})
+        </div>
+
+        <div v-if="events" :id="eventsId" class="collapse">
+            <data-table
+                v-if="events.length"
+                :headers="['Date', 'Evaluated User']"
+            >
+                <tr v-for="event in events" :key="event.id">
+                    <td class="text-nowrap">
+                        {{ new Date(event.deadline).toString().slice(4, 10) }}
+                    </td>
+                    <td>
+                        <user-link
+                            :username="event.user.username"
+                            :osu-id="event.user.osuId"
+                        />
+                    </td>
+                </tr>
+            </data-table>
+            <p v-else class="small ml-4">None...</p>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import DataTable from '../../../../DataTable.vue';
+import UserLink from '../../../../UserLink.vue';
+
+export default {
+    name: 'EvaluationList',
+    components: {
+        DataTable,
+        UserLink,
+    },
+    props: {
+        events: {
+            type: Array,
+            default() {
+                return [];
+            },
+        },
+        header: {
+            type: String,
+            required: true,
+        },
+        eventsId: {
+            type: String,
+            required: true,
+        },
+        mongoId: {
+            type: String,
+            required: true,
+        },
+        isApplication: Boolean,
+    },
+    computed: {
+        ...mapState('activity', ['isLoading']), 
+        ...mapState(['loggedInUser']),
+    },
+};
+</script>

--- a/src/components/evaluations/info/currentBns/userActivity/UserActivity.vue
+++ b/src/components/evaluations/info/currentBns/userActivity/UserActivity.vue
@@ -60,9 +60,10 @@
                 :header="'Disqualified Quality Assurance Checks'"
             />
 
-            <template
+                <template
                 v-if="
-                    loggedInUser.isNat && (natApplications || natBnEvaluations)
+                    (loggedInUser.isNat || selectedUser.isNat) &&
+                    (natApplications || natBnEvaluations)
                 "
             >
                 <div class="mt-2">Evaluations</div>
@@ -106,7 +107,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import EventsList from './EventsList.vue';
 import NominationResets from './NominationResets.vue';
 import EvaluationList from './EvaluationList.vue';
@@ -156,6 +157,7 @@ export default {
     },
     computed: {
         ...mapState(['loggedInUser']),
+        ...mapGetters('users', ['selectedUser']),
         ...mapState('activity', [
             'nominations',
             'nominationsDisqualified',

--- a/src/components/evaluations/info/currentBns/userActivity/UserActivity.vue
+++ b/src/components/evaluations/info/currentBns/userActivity/UserActivity.vue
@@ -60,7 +60,7 @@
                 :header="'Disqualified Quality Assurance Checks'"
             />
 
-                <template
+            <template
                 v-if="
                     (loggedInUser.isNat || selectedUser.isNat) &&
                     (natApplications || natBnEvaluations)

--- a/src/components/evaluations/info/currentBns/userActivity/UserActivity.vue
+++ b/src/components/evaluations/info/currentBns/userActivity/UserActivity.vue
@@ -62,8 +62,8 @@
 
             <template
                 v-if="
-                    (loggedInUser.isNat || selectedUser.isNat) &&
-                    (natApplications || natBnEvaluations)
+                    loggedInUser.isNat &&
+                    (assignedBnApplications || natApplications || natBnEvaluations)
                 "
             >
                 <div class="mt-2">Evaluations</div>
@@ -93,6 +93,29 @@
                 />
             </template>
 
+            <template
+                v-else-if="
+                    !loggedInUser.isNat && selectedUser.isNat &&
+                    (assignedBnApplications || natApplications || natBnEvaluations)
+                "
+            >
+                <div class="mt-2">Evaluations</div>
+                <public-evaluation-list
+                    :events="natApplications"
+                    :events-id="'natApplications'"
+                    :header="'Application Evaluations'"
+                    :is-application="true"
+                    :mongo-id="mongoId"
+                />
+                <public-evaluation-list
+                    :events="natBnEvaluations"
+                    :events-id="'natBnEvaluations'"
+                    :header="'Current BN Evaluations'"
+                    :is-application="false"
+                    :mongo-id="mongoId"
+                />
+            </template>
+
             <template>
                 <div class="mt-2">Modding</div>
                 <events-list
@@ -111,6 +134,7 @@ import { mapState, mapGetters } from 'vuex';
 import EventsList from './EventsList.vue';
 import NominationResets from './NominationResets.vue';
 import EvaluationList from './EvaluationList.vue';
+import PublicEvaluationList from './PublicEvaluationList.vue';
 
 export default {
     name: 'UserActivity',
@@ -118,6 +142,7 @@ export default {
         EventsList,
         NominationResets,
         EvaluationList,
+        PublicEvaluationList,
     },
     props: {
         modes: {
@@ -236,7 +261,7 @@ export default {
                     res.disqualifiedQualityAssuranceChecks
                 );
 
-                if (this.loggedInUser.isNat) {
+                if (this.loggedInUser.isNat || this.selectedUser.isNat) {
                     this.$store.commit(
                         'activity/setBnApplications',
                         res.assignedBnApplications

--- a/src/components/users/NatActivity2.vue
+++ b/src/components/users/NatActivity2.vue
@@ -85,6 +85,7 @@
                 ^user could be assigned to the next evaluation (in the 'bag')
             </div>
             <button
+                v-if="loggedInUser.isResponsibleWithButtons"
                 class="btn btn-sm btn-danger ml-1"
                 @click="cycleBag($event)"
             >
@@ -95,6 +96,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import UserLink from '../UserLink.vue';
 import DataTable from '../DataTable.vue';
 
@@ -113,6 +115,10 @@ export default {
         };
     },
     computed: {
+        ...mapState([
+            'loggedInUser',
+        ]),
+
         /** @returns {boolean} */
         recentlyJoinedNatExists () {
             let recentlyJoinedNatExists;


### PR DESCRIPTION
Evaluations section is now more visible on user cards:

- if you're nat, you'll still see it on everyone's card
- if you're not nat, you'll only see it on nat cards
- actual table only renders if you're nat
- eval count now omits evals that the user didn't vote on, they'll still show up in the table for logging/archival purposes