### PR TITLE
show review status on eval cards

### DIFF
--- a/src/components/evaluations/card/CardHeader.vue
+++ b/src/components/evaluations/card/CardHeader.vue
@@ -14,8 +14,9 @@
                 v-if="feedback"
                 data-toggle="tooltip"
                 data-placement="top"
-                title="feedback written"
+                :title="'feedback written' + (isReviewed ? ' (reviewed)' : ' (needs review)')"
                 class="fas fa-comment mx-1"
+                :class="isReviewed ? 'text-success' : 'text-danger'"
             />
         </p>
         <div v-if="consensus">
@@ -63,6 +64,10 @@ export default {
         feedback: {
             type: String,
             default: '',
+        },
+        isReviewed: {
+            type: Boolean,
+            default: false,
         },
     },
 };

--- a/src/components/evaluations/card/CardHeader.vue
+++ b/src/components/evaluations/card/CardHeader.vue
@@ -16,7 +16,7 @@
                 data-placement="top"
                 :title="'feedback written' + (isReviewed ? ' (reviewed)' : ' (needs review)')"
                 class="fas fa-comment mx-1"
-                :class="isReviewed ? 'text-success' : 'text-danger'"
+                :class="isReviewed ? '' : 'text-warning'"
             />
         </p>
         <div v-if="consensus">

--- a/src/components/evaluations/card/EvaluationCard.vue
+++ b/src/components/evaluations/card/EvaluationCard.vue
@@ -16,6 +16,7 @@
                 :consensus="evaluation.consensus"
                 :addition="evaluation.addition"
                 :feedback="evaluation.feedback"
+                :is-reviewed="evaluation.isReviewed"
             />
 
             <card-footer


### PR DESCRIPTION
![](https://nats.are-la.me/6WmXvEY.png)

initially made the bubble red when feedback is not reviewed so it's easily noticeable, feel free to change it back to white if you think red doesnt look good