### PR TITLE
cleanup request methods

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -93,7 +93,8 @@
         "probationOsu": "",
         "probationTaiko": "",
         "probationCatch": "",
-        "probationMania": ""
+        "probationMania": "",
+        "groupMoversRole": ""
     },
     "admin": {
         "pishifat": 0,

--- a/helpers/discord.js
+++ b/helpers/discord.js
@@ -215,6 +215,8 @@ async function roleHighlightWebhookPost(webhook, roles, text) {
             case 'probationMania':
                 content += `<@&${config.announcementWebhook.probationMania}> `;
                 break;
+            case 'groupMovers':
+                content += `<@&${config.announcementWebhook.groupMoversRole}> `;
         }
     }
 

--- a/routes/evaluations/appEval.js
+++ b/routes/evaluations/appEval.js
@@ -262,7 +262,7 @@ router.post('/setComplete/', middlewares.isNatOrTrialNat, async (req, res) => {
             const userOsuInfo = await osu.getOtherUserInfo(req.session.accessToken, user.osuId);
 
             if (!userOsuInfo.is_supporter) {
-                await discord.userHighlightWebhookPost(evaluation.mode, ['1049780400303644792'], 'give new BN supporter pls ');
+                await discord.roleHighlightWebhookPost(evaluation.mode, ['groupMovers'], 'give new BN supporter pls ');
                 await util.sleep(500);
             }
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,11 @@
                         
                         <!-- normal user -->
                         <template v-if="!loggedInUser.hasBasicAccess && !loggedInUser.hasFullReadAccess">
+                            <li class="nav-item">
+                                <router-link class="nav-link" to="/modrequests">
+                                    Request a BN
+                                </router-link>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">
                                     Other
@@ -53,9 +58,6 @@
                                     </router-link>
                                     <router-link class="dropdown-item" to="/reports">
                                         Reports
-                                    </router-link>
-                                    <router-link class="dropdown-item" to="/modrequests">
-                                        Mod Requests
                                     </router-link>
                                     <router-link class="dropdown-item" to="/vetoes">
                                         Vetoes (read-only)
@@ -70,6 +72,11 @@
                         <!-- BN -->
 
                         <template v-else-if="loggedInUser.hasBasicAccess && !loggedInUser.hasFullReadAccess">
+                            <li class="nav-item">
+                                <router-link class="nav-link" to="/modrequests">
+                                    Request a BN
+                                </router-link>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">
                                     Other
@@ -83,9 +90,6 @@
                                     </router-link>
                                     <router-link class="dropdown-item" to="/reports">
                                         Reports
-                                    </router-link>
-                                    <router-link class="dropdown-item" to="/modrequests">
-                                        Mod Request Submission
                                     </router-link>
                                 </div>
                             </li>
@@ -107,7 +111,7 @@
                                         Quality Assurance
                                     </router-link>
                                     <router-link class="dropdown-item" to="/modrequests/listing">
-                                        Mod Request Listing
+                                        BN Finder / Global Queue
                                     </router-link>
                                 </div>
                             </li>
@@ -166,10 +170,10 @@
                                         Quality Assurance
                                     </router-link>
                                     <router-link class="dropdown-item" to="/modrequests">
-                                        Mod Request Submission
+                                        Request a BN
                                     </router-link>
                                     <router-link class="dropdown-item" to="/modrequests/listing">
-                                        Mod Request Listing
+                                        BN Finder / Global Queue
                                     </router-link>
                                 </div>
                             </li>

--- a/src/components/modRequests/BnFinder.vue
+++ b/src/components/modRequests/BnFinder.vue
@@ -310,7 +310,7 @@
 <script>
 import { mapState } from 'vuex';
 import evaluations from '../../mixins/evaluations';
-import UserLink from '../../components/UserLink.vue';
+import UserLink from '../UserLink.vue';
 import ModeRadioDisplay from '../ModeRadioDisplay.vue';
 import {
     GenrePreferences,

--- a/src/components/modRequests/BnFinderMatches.vue
+++ b/src/components/modRequests/BnFinderMatches.vue
@@ -133,7 +133,7 @@
 </template>
 
 <script>
-import UserLink from '../../components/UserLink.vue';
+import UserLink from '../UserLink.vue';
 
 export default {
     name: 'BnFinderMatches',

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,10 +1,6 @@
 <template>
     <div>
         <announcements />
-        <bn-finder />
-        <bn-finder-matches
-            v-if="loggedInUser && loggedInUser.isBnOrNat"
-        />
         <section class="card card-body">
             <h4 class="mx-auto mb-3">
                 Current Beatmap Nominators
@@ -50,9 +46,7 @@
 import { mapState } from 'vuex';
 import evaluations from '../mixins/evaluations';
 import ToastMessages from '../components/ToastMessages.vue';
-import BnFinder from '../components/home/BnFinder.vue';
 import Announcements from '../components/home/Announcements.vue';
-import BnFinderMatches from '../components/home/BnFinderMatches.vue';
 import UserLink from '../components/UserLink.vue';
 import UserCard from '../components/home/UserCard.vue';
 
@@ -60,9 +54,7 @@ export default {
     name: 'Index',
     components: {
         ToastMessages,
-        BnFinder,
         Announcements,
-        BnFinderMatches,
         UserLink,
         UserCard,
     },

--- a/src/pages/ModRequests.vue
+++ b/src/pages/ModRequests.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="row">
         <div class="col-sm">
+            <bn-finder-matches />
             <requests-listing
                 v-if="involvedRequests.length"
                 v-slot="{ request }"
@@ -70,6 +71,7 @@ import RequestRow from '../components/modRequests/RequestRow.vue';
 import RequestInfo from '../components/modRequests/RequestInfo.vue';
 import RequestTag from '../components/modRequests/RequestTag.vue';
 import ToastMessages from '../components/ToastMessages.vue';
+import BnFinderMatches from '../components/modRequests/BnFinderMatches.vue';
 
 export default {
     name: 'ModRequests',
@@ -79,6 +81,7 @@ export default {
         RequestInfo,
         RequestTag,
         ToastMessages,
+        BnFinderMatches,
     },
     computed: {
         ...mapState('modRequests', [

--- a/src/pages/ModRequestsSubmission.vue
+++ b/src/pages/ModRequestsSubmission.vue
@@ -1,9 +1,41 @@
 <template>
     <div class="row">
         <div class="col-sm">
+            <section class="card card-body">
+                <h4 class="mx-auto mb-3">
+                    Open Beatmap Nominators
+                </h4>
+                <p class="mx-auto mb-3 text-center">This is a list of Beatmap Nominators who are currently open for requests. Make sure to pay attention to their request methods and guidelines listed in their userpages!</p>
+                <transition-group
+                    appear
+                    name="route-transition"
+                    mode="out-in"
+                    tag="div"
+                    class="row align-items-start"
+                >
+                    <table v-for="usersByMode in sortedList" :key="usersByMode._id" class="table table-sm table-dark table-hover col-6 col-md-3">
+                        <thead>
+                            <td>{{ usersByMode._id == 'osu' ? 'osu!' : 'osu!' + usersByMode._id }}</td>
+                        </thead>
+                        <tbody>
+                            <tr v-for="user in usersByMode.users" :key="user.id"> 
+                                <user-card :user="user" />
+                            </tr>
+                        </tbody>
+                    </table>
+                </transition-group>
+            </section>
+            <div class="alert alert-danger mb-2">
+                <i class="fas fa-exclamation-triangle"></i>
+                The request methods below are rarely used and do not guarantee that your request will receive a response. Please use the table above instead.
+            </div>
+            <bn-finder />
             <section class="card">
                 <div class="card-body">
                     <div class="row">
+                        <div class="col-sm-12">
+                            <h4 class="mb-2">Global Queue</h4>
+                        </div>
                         <div class="col-sm-12">
                             <p>If you're a mapper, this page lets you submit requests to Beatmap Nominators without asking people individually.</p>
                             <p>If you're a Beatmap Nominator, this page lets you view maps from a variety of creators and select any that you're interested in modding.</p>
@@ -83,7 +115,7 @@
 
             <template v-if="ownRequests.length">
                 <requests-listing
-                    title="My Requests"
+                    title="Global Queue Requests"
                     :requests="ownRequests"
                 >
                     <template v-slot="{ request }">
@@ -116,6 +148,8 @@ import RequestsListing from '../components/modRequests/RequestsListing.vue';
 import EditRequestModal from '../components/modRequests/EditRequestModal.vue';
 import MyRequestRow from '../components/modRequests/MyRequestRow.vue';
 import ToastMessages from '../components/ToastMessages.vue';
+import BnFinder from '../components/modRequests/BnFinder.vue';
+import UserCard from '../components/home/UserCard.vue';
 
 export default {
     name: 'ModRequestsSubmission',
@@ -124,6 +158,8 @@ export default {
         EditRequestModal,
         MyRequestRow,
         ToastMessages,
+        BnFinder,
+        UserCard,
     },
     data () {
         return {
@@ -135,10 +171,26 @@ export default {
     computed: {
         ...mapState([
             'loggedInUser',
+            'allUsersByMode',
         ]),
         ...mapState('modRequests', [
             'ownRequests',
         ]),
+        sortedList() {
+            const sortOrder = ['osu', 'taiko', 'catch', 'mania'];
+            const sorted = [...this.allUsersByMode];
+
+            // filter out users who have "closed" in their requestStatus array
+            sorted.forEach((mode) => {
+                mode.users = mode.users.filter((user) => {
+                    return (!user.requestStatus?.includes('closed') && user.requestStatus?.length);
+                });
+            });
+
+            return sorted.sort(function(a, b) {
+                return sortOrder.indexOf(a._id) - sortOrder.indexOf(b._id);
+            });
+        },
     },
     beforeCreate () {
         if (!this.$store.hasModule('modRequests')) {
@@ -149,6 +201,14 @@ export default {
         if (this.loggedInUser) {
             const data = await this.$http.initialRequest('/modRequests/owned');
             if (!data.error) this.$store.commit('modRequests/setOwnRequests', data);
+        }
+        if (this.allUsersByMode.length) return;
+
+        const userData = await this.$http.executeGet('/relevantInfo');
+
+        //! FIXME fix the bug where if you go from /modRequests to /home, the bn table will continue to show open users only, instead of all users
+        if (userData.allUsersByMode) {
+            this.$store.commit('setOpenUsersData', userData.allUsersByMode);
         }
     },
     methods: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -36,12 +36,12 @@ const routes = [
     { path: '/testresults', component: TestResults, meta: { title: 'Ranking Criteria Test Results' } },
     { path: '/yourevals', component: YourEvals, meta: { title: 'Your Evaluations' } },
     { path: '/message', component: Message, meta: { title: 'Message from the NAT' } },
-    { path: '/modrequests', component: ModRequestsSubmission, meta: { title: 'Mod Requests', public: true } },
+    { path: '/modrequests', component: ModRequestsSubmission, meta: { title: 'Request a BN', public: true } },
 
     // BN/NAT
     { path: '/discussionvote', component: DiscussionVote, meta: { title: 'Content Review', requiresBasicAccess: true } },
     { path: '/appeval', component: AppEvalPage, meta: { title: 'BN Application Evaluations', requiresBasicAccess: true } },
-    { path: '/modrequests/listing', component: ModRequests, meta: { title: 'Mod Requests Listing', requiresBasicAccess: true } },
+    { path: '/modrequests/listing', component: ModRequests, meta: { title: 'BN Finder / Global Queue', requiresBasicAccess: true } },
 
     // NAT and Trial NAT
     { path: '/bneval', component: BnEvalPage, meta: { title: 'Current BN Evaluations', requiresFullReadAccessOrTrialNat: true } },

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -16,6 +16,7 @@ const store = new Vuex.Store({
         isLoading: false,
         loggedInUser: null,
         allUsersByMode: [],
+        allOpenUsersByMode: [],
     },
     getters: {
         userMainMode (state) {
@@ -37,8 +38,8 @@ const store = new Vuex.Store({
         setHomeData (state, allUsersByMode) {
             state.allUsersByMode = allUsersByMode;
         },
-        setOpenUsersData (state, allUsersByMode) {
-            state.allUsersByMode = allUsersByMode;
+        setOpenUsersData (state, allOpenUsersByMode) {
+            state.allOpenUsersByMode = allOpenUsersByMode;
         },
         updateLoadingState (state) {
             state.isLoading = !state.isLoading;

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -40,6 +40,9 @@ const store = new Vuex.Store({
         setOpenUsersData (state, allUsersByMode) {
             state.allUsersByMode = allUsersByMode;
         },
+        updateLoadingState (state) {
+            state.isLoading = !state.isLoading;
+        },
     },
     actions: {
         async setInitialData ({ commit }) {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -37,8 +37,8 @@ const store = new Vuex.Store({
         setHomeData (state, allUsersByMode) {
             state.allUsersByMode = allUsersByMode;
         },
-        updateLoadingState (state) {
-            state.isLoading = !state.isLoading;
+        setOpenUsersData (state, allUsersByMode) {
+            state.allUsersByMode = allUsersByMode;
         },
     },
     actions: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -16,7 +16,6 @@ const store = new Vuex.Store({
         isLoading: false,
         loggedInUser: null,
         allUsersByMode: [],
-        allOpenUsersByMode: [],
     },
     getters: {
         userMainMode (state) {
@@ -37,9 +36,6 @@ const store = new Vuex.Store({
         },
         setHomeData (state, allUsersByMode) {
             state.allUsersByMode = allUsersByMode;
-        },
-        setOpenUsersData (state, allOpenUsersByMode) {
-            state.allOpenUsersByMode = allOpenUsersByMode;
         },
         updateLoadingState (state) {
             state.isLoading = !state.isLoading;


### PR DESCRIPTION
- move BN finder to /modrequests and /modrequests/listing
- added open BNs table to /modrequests
- added alert about unused req methods
- did some page renaming

bug: when you go to /modrequests, then back to /home, the BN table will still show only open users instead of all users. would really appreciate if you could fix this because i cba dealing with vue state fuckery :sob: