### PR TITLE
preview buttons + various qol fixes

### DIFF
--- a/src/components/evaluations/AddEvaluations.vue
+++ b/src/components/evaluations/AddEvaluations.vue
@@ -5,120 +5,75 @@
                 <div class="col-sm-12">
                     <b class="mr-4">Game mode:</b>
 
-                    <mode-radio-display
-                        v-model="selectedModes"
-                        class="ml-2"
-                        input-type="checkbox"
-                    />
+                    <mode-radio-display v-model="selectedModes" class="ml-2" input-type="checkbox" />
 
-                    <p class="small text-secondary ml-2">
+                    <p class="small text-secondary ml-2 mt-1">
                         Specify mode(s) for evaluations. Multi-mode BNs can generate multiple evaluations.
                     </p>
                 </div>
             </div>
-
             <div class="row mb-3">
-                <div class="col-sm-12">
-                    <b class="mr-4">User group:</b>
-                    <label
-                        class="mx-2"
-                        data-toggle="tooltip"
-                        data-placement="top"
-                        title="probation BN"
-                    >
-                        <input
-                            v-model="groups"
-                            type="checkbox"
-                            class="probation-bn-radio hide-default"
-                            value="probationBn"
-                        >
-                        <i class="fab fa-accessible-icon" />
-                    </label>
-                    <label
-                        class="mx-2"
-                        data-toggle="tooltip"
-                        data-placement="top"
-                        title="full BN"
-                    >
-                        <input
-                            v-model="groups"
-                            type="checkbox"
-                            class="full-bn-radio hide-default"
-                            value="fullBn"
-                        >
-                        <i class="fas fa-walking" />
-                    </label>
-                    <label
-                        class="mx-2"
-                        data-toggle="tooltip"
-                        data-placement="top"
-                        title="NAT"
-                    >
-                        <input
-                            v-model="groups"
-                            type="checkbox"
-                            class="nat-radio hide-default"
-                            value="nat"
-                        >
-                        <i class="fas fa-running" />
-                    </label>
-
-                    <p class="small text-secondary ml-2">
-                        Generate evaluations for all members of a user group. Only use this if you know what you're doing.
-                    </p>
+                <div class="col-sm-6">
+                    <b>User(s):</b>
+                    <input v-model="includeUsers" class="ml-2 form-control" type="text"
+                        placeholder="username1, username2, username3...">
                 </div>
             </div>
 
             <div class="row mb-3">
-                <div class="col-sm-6">
-                    <b>Include specific user(s):</b>
-                    <input
-                        v-model="includeUsers"
-                        class="ml-2 form-control"
-                        type="text"
-                        placeholder="username1, username2, username3..."
-                    >
-                </div>
-                <div class="col-sm-6">
-                    <b>Exclude specific user(s):</b>
-                    <input
-                        v-model="excludeUsers"
-                        class="ml-2 form-control"
-                        type="text"
-                        placeholder="username1, username2, username3..."
-                    >
-                </div>
-            </div>
-
-            <div class="row">
                 <div class="col-sm-12">
                     <b>Resignation:</b>
 
                     <div class="form-check ml-2">
-                        <input
-                            id="isResignation"
-                            v-model="isResignation"
-                            class="form-check-input"
-                            type="checkbox"
-                        >
+                        <input id="isResignation" v-model="isResignation" class="form-check-input" type="checkbox">
                         <label class="form-check-label text-secondary small" for="isResignation">
-                            Checking this will replace vote/consensus options with "resigned on good/standard terms" and set deadline to today.
+                            Checking this will replace vote/consensus options with "resigned on good/standard terms" and set
+                            deadline to today.
                         </label>
                     </div>
                 </div>
-                <div v-if="!isResignation" class="col-sm-12">
+                <div v-if="!isResignation" class="col-sm-12 mt-3">
                     <div class="form-inline">
                         <b>Deadline:</b>
-                        <input
-                            v-model="deadline"
-                            class="ml-1 form-control"
-                            type="date"
-                        >
+                        <input v-model="deadline" class="ml-1 form-control" type="date">
                     </div>
 
                     <small class="text-secondary ml-2 mt-1">
                         Only deadlines within the next week will be displayed.
                     </small>
+                </div>
+            </div>
+            <div v-if="loggedInUser.isResponsibleWithButtons" class="row">
+                <div class="col-sm-12">
+                    <p>
+                        <a href="#advancedSettings" data-toggle="collapse">
+                            Advanced settings <i class="fas fa-angle-down" />
+                        </a>
+                    </p>
+                    <div id="advancedSettings" class="collapse container col-sm-12">
+                        <b class="mr-4">User group:</b>
+                        <label class="mx-2" data-toggle="tooltip" data-placement="top" title="probation BN">
+                            <input v-model="groups" type="checkbox" class="probation-bn-radio hide-default" value="probationBn">
+                            <i class="fab fa-accessible-icon" />
+                        </label>
+                        <label class="mx-2" data-toggle="tooltip" data-placement="top" title="full BN">
+                            <input v-model="groups" type="checkbox" class="full-bn-radio hide-default" value="fullBn">
+                            <i class="fas fa-walking" />
+                        </label>
+                        <label class="mx-2" data-toggle="tooltip" data-placement="top" title="NAT">
+                            <input v-model="groups" type="checkbox" class="nat-radio hide-default" value="nat">
+                            <i class="fas fa-running" />
+                        </label>
+
+                        <p class="small text-secondary ml-2">
+                            Generate evaluations for all members of a user group. Only use this if you know what you're doing.
+                        </p>
+                        <div class="col-sm-6">
+                            <b>Exclude specific user(s):</b>
+                            <input v-model="excludeUsers" class="ml-2 form-control" type="text"
+                                placeholder="username1, username2, username3...">
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -132,6 +87,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import ModalDialog from '../ModalDialog.vue';
 import ModeRadioDisplay from '../ModeRadioDisplay.vue';
 
@@ -140,6 +96,11 @@ export default {
     components: {
         ModalDialog,
         ModeRadioDisplay,
+    },
+    computed: {
+        ...mapState([
+            'loggedInUser',
+        ]),
     },
     data() {
         return {

--- a/src/components/evaluations/info/common/EvaluationInput.vue
+++ b/src/components/evaluations/info/common/EvaluationInput.vue
@@ -7,10 +7,26 @@
             <div class="col-sm-12">
                 <p>
                     <b>{{ selectedEvaluation.user.isNat && loggedInUser.isNatLeader ? 'NAT activity comments:' : 'Modding comments:' }}</b>
+                    <a
+                        class="ml-1"
+                        data-toggle="tooltip"
+                        data-placement="top"
+                        title="toggle comment preview"
+                        href="#"
+                        @click.prevent="togglePreviewModdingComment()"
+                    >
+                        <i class="fas fa-search" />
+                    </a>
                 </p>
 
                 <div class="form-group">
+                    <div 
+                        v-if="previewModdingComment" 
+                        class="small ml-2 card card-body" 
+                        v-html="$md.render(moddingComment)"
+                    />
                     <textarea
+                        v-else
                         v-model="moddingComment"
                         class="form-control"
                         rows="4"
@@ -22,10 +38,26 @@
             <div class="col-sm-12">
                 <p>
                     <b>Behavior comments:</b>
+                    <a
+                        class="ml-1"
+                        data-toggle="tooltip"
+                        data-placement="top"
+                        title="toggle comment preview"
+                        href="#"
+                        @click.prevent="togglePreviewBehaviorComment()"
+                    >
+                        <i class="fas fa-search" />
+                    </a>
                 </p>
 
                 <div class="form-group">
+                    <div 
+                        v-if="previewBehaviorComment" 
+                        class="small ml-2 card card-body" 
+                        v-html="$md.render(behaviorComment)"
+                    />
                     <textarea
+                    v-else
                         v-model="behaviorComment"
                         class="form-control"
                         rows="4"
@@ -45,7 +77,7 @@
                     name="vote"
                     value="1"
                 >
-                <label class="form-check-label text-pass" for="1">{{ selectedEvaluation.isApplication ? 'Pass' : selectedEvaluation.user.evaluatorModes.includes(selectedEvaluation.mode) && loggedInUser.isNatLeader ? 'Remain in NAT' : selectedEvaluation.isBnEvaluation ? 'Full BN' : 'Resign on good terms' }}</label>
+                <label class="form-check-label text-pass" for="1">{{ selectedEvaluation.isApplication ? 'Pass' : (selectedEvaluation.user.evaluatorModes.includes(selectedEvaluation.mode) || selectedEvaluation.user.evaluatorModes.includes("none")) && loggedInUser.isNatLeader ? 'Remain in NAT' : selectedEvaluation.isBnEvaluation ? 'Full BN' : 'Resign on good terms' }}</label>
             </div>
             <div class="form-check form-check-inline">
                 <input
@@ -56,7 +88,7 @@
                     name="vote"
                     value="2"
                 >
-                <label class="form-check-label text-neutral" for="2">{{ selectedEvaluation.isApplication ? 'Neutral' : selectedEvaluation.user.evaluatorModes.includes(selectedEvaluation.mode) && loggedInUser.isNatLeader ? 'Investigate' : selectedEvaluation.isBnEvaluation ? 'Probation BN' : 'Resign on standard terms' }}</label>
+                <label class="form-check-label text-neutral" for="2">{{ selectedEvaluation.isApplication ? 'Neutral' : (selectedEvaluation.user.evaluatorModes.includes(selectedEvaluation.mode) || selectedEvaluation.user.evaluatorModes.includes("none")) && loggedInUser.isNatLeader ? 'Investigate' : selectedEvaluation.isBnEvaluation ? 'Probation BN' : 'Resign on standard terms' }}</label>
             </div>
             <div v-if="!selectedEvaluation.isResignation" class="form-check form-check-inline">
                 <input
@@ -67,7 +99,7 @@
                     name="vote"
                     value="3"
                 >
-                <label class="form-check-label text-fail" for="3">{{ selectedEvaluation.isApplication ? 'Fail' : selectedEvaluation.user.evaluatorModes.includes(selectedEvaluation.mode) && loggedInUser.isNatLeader ? 'Remove from NAT' : 'Remove from BN' }}</label>
+                <label class="form-check-label text-fail" for="3">{{ selectedEvaluation.isApplication ? 'Fail' : (selectedEvaluation.user.evaluatorModes.includes(selectedEvaluation.mode) || selectedEvaluation.user.evaluatorModes.includes("none")) && loggedInUser.isNatLeader ? 'Remove from NAT' : 'Remove from BN' }}</label>
             </div>
 
             <button class="btn btn-sm btn-primary" @click="submitEval($event)">
@@ -94,6 +126,10 @@ export default {
         ...mapState([
             'loggedInUser',
         ]),
+        ...mapState('evaluations', [
+            'previewModdingComment',
+            'previewBehaviorComment',
+        ]),
         ...mapGetters('evaluations', [
             'selectedEvaluation',
         ]),
@@ -113,6 +149,12 @@ export default {
         this.findUserReview();
     },
     methods: {
+        togglePreviewModdingComment() {
+            this.$store.commit('evaluations/togglePreviewModdingComment');
+        },
+        togglePreviewBehaviorComment() {
+            this.$store.commit('evaluations/togglePreviewBehaviorComment');
+        },
         updateLocalStorage(type, text) {
             window.localStorage.setItem(this.selectedEvaluation.id + type, text);
         },

--- a/src/components/evaluations/info/common/FeedbackInfo.vue
+++ b/src/components/evaluations/info/common/FeedbackInfo.vue
@@ -3,8 +3,21 @@
         <div v-if="!selectedEvaluation.isResignation">
             <p class="mb-2">
                 <b>Feedback:</b>
+                <a
+                    class="ml-1"
+                    data-toggle="tooltip"
+                    data-placement="top"
+                    title="toggle feedback preview"
+                    href="#"
+                    @click.prevent="togglePreviewFeedback()"
+                >
+                    <i class="fas fa-search" />
+                </a>
             </p>
-            <textarea v-model="feedback" class="form-control mb-2" rows="4" />
+
+            <div v-if="previewFeedback" class="small ml-2 card card-body" v-html="$md.render(feedback)" />
+            
+            <textarea v-else v-model="feedback" class="form-control mb-2" rows="4" />
 
             <button
                 class="btn btn-sm btn-block btn-primary my-2 ml-0 ml-sm-auto"
@@ -12,6 +25,8 @@
             >
                 Save feedback
             </button>
+
+        <hr />
 
             <input
                 v-if="selectedEvaluation.isApplication && positiveConsensus"
@@ -37,7 +52,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import evaluations from '../../../../mixins/evaluations.js';
 import FeedbackPm from './FeedbackPm.vue';
 
@@ -54,7 +69,9 @@ export default {
         };
     },
     computed: {
+        ...mapState('evaluations', ['previewFeedback']),
         ...mapGetters('evaluations', ['selectedEvaluation']),
+
         /** @returns {string} */
         consensus() {
             return this.selectedEvaluation.consensus;
@@ -67,8 +84,12 @@ export default {
     },
     mounted() {
         this.feedback = this.selectedEvaluation.feedback;
+        this.$store.commit('evaluations/resetPreviewState');
     },
     methods: {
+        togglePreviewFeedback() {
+            this.$store.commit('evaluations/togglePreviewFeedback');
+        },
         async setFeedback(e) {
             const result = await this.$http.executePost(
                 `/${

--- a/src/components/vetoes/info/AdminButtons.vue
+++ b/src/components/vetoes/info/AdminButtons.vue
@@ -67,11 +67,6 @@
                 {{ mediators ? 'Re-select mediators' : 'Select mediators' }}
             </button>
 
-            <!-- begin mediation -->
-            <button v-if="mediators && mediators.length" class="btn btn-sm btn-block btn-success mb-2" @click="beginMediation($event)">
-                Begin mediation
-            </button>
-
             <!-- view mediators -->
             <div v-if="mediators" class="mt-2 row">
                 <div class="col-sm-3 align-self-center">
@@ -92,6 +87,12 @@
                     />
                 </div>
             </div>
+
+            <!-- begin mediation -->
+            <button v-if="mediators && mediators.length" class="btn btn-sm btn-block btn-success my-2" @click="beginMediation($event)">
+                Begin mediation
+            </button>
+
         </div>
     </div>
 </template>
@@ -144,14 +145,18 @@ export default {
             }
         },
         async beginMediation (e) {
-            const result = confirm(`Are you sure?`);
+            const result = confirm(`Make sure to send messages prior to starting a mediation. If you've already done this, press OK.`);
 
             if (result) {
-                const mediatorIds = this.mediators.map(m => m._id);
-                const veto = await this.$http.executePost(`/vetoes/beginMediation/${this.selectedVeto.id}`, { mediatorIds, reasons: this.selectedVeto.reasons }, e);
+                const result2 = confirm(`ARE YOU REALLY SURE YOU'VE SENT THE MESSAGES? DON'T BE STUPID.`);
 
-                this.commitVeto(veto, 'Started veto mediation');
-            }
+                if (result2) {
+                    const mediatorIds = this.mediators.map(m => m._id);
+                    const veto = await this.$http.executePost(`/vetoes/beginMediation/${this.selectedVeto.id}`, { mediatorIds, reasons: this.selectedVeto.reasons }, e);
+
+                    this.commitVeto(veto, 'Started veto mediation');
+                }
+            } 
         },
         async concludeMediation (e, dismiss) {
             const result = confirm(`Are you sure?`);

--- a/src/store/evaluations.js
+++ b/src/store/evaluations.js
@@ -10,18 +10,33 @@ export default {
         evaluations: [],
         selectedEvaluationId: null,
         checkedEvaluations: [],
+        previewFeedback: false,
+        previewModdingComment: false,
+        previewBehaviorComment: false,
     }),
     mutations: {
         resetState (state) {
             state.evaluations = [];
             state.selectedEvaluationId = null;
             state.checkedEvaluations = [];
+            state.previewFeedback = false;
+            state.previewModdingComment = false;
+            state.previewBehaviorComment = false;
         },
         setEvaluations (state, evaluations) {
             state.evaluations = evaluations;
         },
         setSelectedEvaluationId (state, id) {
             state.selectedEvaluationId = id;
+        },
+        togglePreviewFeedback (state) {
+            state.previewFeedback = !state.previewFeedback;
+        },
+        togglePreviewModdingComment (state) {
+            state.previewModdingComment = !state.previewModdingComment;
+        },
+        togglePreviewBehaviorComment (state) {
+            state.previewBehaviorComment = !state.previewBehaviorComment;
         },
 
         // modify data


### PR DESCRIPTION
this pr:

- adds preview buttons to eval feedback and comments
- fixes bug where it'll show bn consensus options on structural nat evals
- fixes ux issue where nats have started mediation without sending messages by:
  - adding extra confirmation dialogs
  - moving the "begin mediation" button below "send messages" to better indicate the intended order
- re-organizes the `AddEvaluations` modal by hiding big oopsie buttons (the "eval usergroup" ones) and locking them behind the `isResponsibleWithButtons` perm