### PR TITLE
add security check toggle in evals

### DIFF
--- a/helpers/discord.js
+++ b/helpers/discord.js
@@ -253,7 +253,7 @@ function defaultWebhookAuthor(session) {
 
 const webhookColors = {
     lightRed: 16742771,       // active: moveToGroupDiscussion, almostOverdueNotifications
-    darkRed: 8787477,         // report
+    darkRed: 8787477,         // report, toggleIsSecurityChecked
     red: 15607337,            // overdueNotifications, problemReport, lowActivity
 
     lightOrange: 15639928,    // enableBnEvaluators, suggestionReport
@@ -276,12 +276,13 @@ const webhookColors = {
     darkPurple: 4263999,      // submitVeto
     purple: 8536232,          // startVetoMediation, concludeVetoMediation
 
-    pink: 16728232,       // revealedCurrentBnEvalNotification, modified report, toggleHasTrialNat
-    lightPink: 16748236,  // isTrialNat, SEV
-    white: 15724527,      // unarchive, addEvaluation, sendMessages
-    brown: 7554849,       // submitUserNote
-    gray: 8815494,        // passive: moveToGroupDiscussion, dev
-    black: 2564903,       // archive, deleteVeto
+    pink: 16728232,           // revealedCurrentBnEvalNotification, modified report, toggleHasTrialNat
+    lightPink: 16748236,      // isTrialNat, SEV, toggleIsBannedFromBn, editBadgeValue
+
+    white: 15724527,          // unarchive, addEvaluation, sendMessages
+    brown: 7554849,           // submitUserNote
+    gray: 8815494,            // passive: moveToGroupDiscussion, dev
+    black: 2564903,           // archive, deleteVeto
 };
 
 async function discussionWebhookPost(d, session) {

--- a/models/evaluations/base.js
+++ b/models/evaluations/base.js
@@ -5,6 +5,7 @@ const baseSchema = {
     active: { type: Boolean, default: true },
     discussion: { type: Boolean, default: false },
     isReviewed: { type: Boolean, default: false },
+    isSecurityChecked: { type: Boolean, default: false },
     feedback: { type: String },
     cooldownDate: { type: Date },
     natEvaluators: [{ type: 'ObjectId', ref: 'User' }],

--- a/models/interfaces/evaluations.ts
+++ b/models/interfaces/evaluations.ts
@@ -20,6 +20,7 @@ interface IEvaluationBase {
     isBnEvaluation?: boolean;
     isResignation?: boolean;
     isReviewed?: boolean;
+    isSecurityChecked?: boolean;
     natEvaluatorHistory: {
         date: Date;
         user: IUserDocument;

--- a/routes/evaluations/appEval.js
+++ b/routes/evaluations/appEval.js
@@ -648,13 +648,39 @@ router.post('/toggleIsReviewed/:id', middlewares.isNat, async (req, res) => {
     discord.webhookPost([{
         author: discord.defaultWebhookAuthor(req.session),
         color: discord.webhookColors.lightPurple,
-        description: `${app.isReviewed ? 'Reviewed feedback for ' : 'Unmarked feedback as reviewed for '} [**${app.user.username}**'s BN app](http://bn.mappersguild.com/appeval?id=${app.id})`,
+        description: `${app.isReviewed ? 'Reviewed feedback for' : 'Unmarked feedback as reviewed for'} [**${app.user.username}**'s BN app](http://bn.mappersguild.com/appeval?id=${app.id})`,
     }],
     app.mode);
 
     Logger.generate(
         req.session.mongoId,
         `Toggled "${app.user.username}" ${app.mode} BN app isReviewed to ${app.isReviewed}`,
+        'appEvaluation',
+        app._id
+    );
+});
+
+/* POST toggle isSecurityChecked for evaluations */
+router.post('/toggleIsSecurityChecked/:id', middlewares.isNat, async (req, res) => {
+    const app = await AppEvaluation
+        .findById(req.params.id)
+        .populate(defaultPopulate);
+        
+    app.isSecurityChecked = !app.isSecurityChecked;
+    await app.save();
+
+    res.json(app);
+
+    discord.webhookPost([{
+        author: discord.defaultWebhookAuthor(req.session),
+        color: discord.webhookColors.darkRed,
+        description: `${app.isSecurityChecked ? 'Marked' : 'Unmarked'} [**${app.user.username}**'s BN app](http://bn.mappersguild.com/appeval?id=${app.id}) as security checked`,
+    }],
+    app.mode);
+
+    Logger.generate(
+        req.session.mongoId,
+        `Toggled "${app.user.username}" ${app.mode} BN app isSecurityChecked to ${app.isSecurityChecked}`,
         'appEvaluation',
         app._id
     );

--- a/routes/evaluations/bnEval.js
+++ b/routes/evaluations/bnEval.js
@@ -1143,7 +1143,7 @@ router.post('/toggleIsReviewed/:id', middlewares.isNat, async (req, res) => {
     discord.webhookPost([{
         author: discord.defaultWebhookAuthor(req.session),
         color: discord.webhookColors.lightPurple,
-        description: `${er.isReviewed ? 'Reviewed feedback for ' : 'Unmarked feedback as reviewed for '} [**${er.user.username}**'s current BN eval](http://bn.mappersguild.com/bneval?id=${er.id})`,
+        description: `${er.isReviewed ? 'Reviewed feedback for' : 'Unmarked feedback as reviewed for'} [**${er.user.username}**'s current BN eval](http://bn.mappersguild.com/bneval?id=${er.id})`,
     }],
     er.mode);
 

--- a/src/components/BotChatMessage.vue
+++ b/src/components/BotChatMessage.vue
@@ -4,13 +4,23 @@
             <span v-html="$md.render(message)" />
         </div>
 
-        <a v-if="users.length && !isReviewable || isReviewed" class="btn btn-sm btn-block btn-success mb-2" @click="sendMessage($event)">
+        <a v-if="
+            users.length &&
+            ((!isReviewable || (isReviewed && !isSecurityCheckable)) || (isReviewed && isSecurityCheckable && isSecurityChecked))
+            "
+            class="btn btn-sm btn-block btn-success mb-2" 
+            @click="sendMessage($event)"
+        >
             {{ customText }}
         </a>
-        <div v-if="isReviewable && !isReviewed" class="alert alert-primary mb-2 mt-2">
-                <i class="fas fa-exclamation-triangle"></i>
-                Feedback needs to be marked as reviewed before sending!
-            </div>
+        <div v-if="isSecurityCheckable && !isSecurityChecked" class="alert alert-danger mb-2 mt-2">
+            <i class="fas fa-exclamation-triangle"></i>
+            User needs to be marked as security checked before proceeding!
+        </div>
+        <div v-else-if="isReviewable && !isReviewed" class="alert alert-warning mb-2 mt-2">
+            <i class="fas fa-exclamation-triangle"></i>
+            Feedback needs to be marked as reviewed before sending!
+        </div>
     </div>
 </template>
 
@@ -53,6 +63,14 @@ export default {
             default: false,
         },
         isReviewed: {
+            type: Boolean,
+            default: true,
+        },
+        isSecurityCheckable: {
+            type: Boolean,
+            default: false,
+        },
+        isSecurityChecked: {
             type: Boolean,
             default: true,
         },

--- a/src/components/evaluations/card/CardHeader.vue
+++ b/src/components/evaluations/card/CardHeader.vue
@@ -11,7 +11,7 @@
             <i v-else-if="mode == 'catch'" class="fas fa-apple-alt mx-1" />
             <i v-else-if="mode == 'mania'" class="fas fa-stream mx-1" />
             <i
-                v-if="feedback"
+                v-if="feedback && !isReviewed"
                 data-toggle="tooltip"
                 data-placement="top"
                 :title="'feedback written' + (isReviewed ? ' (reviewed)' : ' (needs review)')"
@@ -19,12 +19,12 @@
                 :class="isReviewed ? '' : 'text-warning'"
             />
             <i
-                v-if="isSecurityCheckable && isNatOrTrialNat"
+                v-if="isSecurityCheckable && isNatOrTrialNat && !isSecurityChecked"
                 data-toggle="tooltip"
                 data-placement="top"
                 :title="isSecurityChecked ? 'is security checked' : 'needs a security check'"
                 class="fas fa-shield-alt mr-1"
-                :class="isSecurityChecked ? '' : 'text-danger'"
+                :class="isSecurityChecked ? '' : 'text-warning'"
             />
         </p>
         <div v-if="consensus">

--- a/src/components/evaluations/card/CardHeader.vue
+++ b/src/components/evaluations/card/CardHeader.vue
@@ -15,8 +15,16 @@
                 data-toggle="tooltip"
                 data-placement="top"
                 :title="'feedback written' + (isReviewed ? ' (reviewed)' : ' (needs review)')"
-                class="fas fa-comment mx-1"
+                class="fas fa-comment mr-1"
                 :class="isReviewed ? '' : 'text-warning'"
+            />
+            <i
+                v-if="isSecurityCheckable && isNatOrTrialNat"
+                data-toggle="tooltip"
+                data-placement="top"
+                :title="isSecurityChecked ? 'is security checked' : 'needs a security check'"
+                class="fas fa-shield-alt mr-1"
+                :class="isSecurityChecked ? '' : 'text-danger'"
             />
         </p>
         <div v-if="consensus">
@@ -66,6 +74,18 @@ export default {
             default: '',
         },
         isReviewed: {
+            type: Boolean,
+            default: false,
+        },
+        isSecurityCheckable: {
+            type: Boolean,
+            default: false,
+        },
+        isSecurityChecked: {
+            type: Boolean,
+            default: false,
+        },
+        isNatOrTrialNat: {
             type: Boolean,
             default: false,
         },

--- a/src/components/evaluations/card/EvaluationCard.vue
+++ b/src/components/evaluations/card/EvaluationCard.vue
@@ -17,6 +17,9 @@
                 :addition="evaluation.addition"
                 :feedback="evaluation.feedback"
                 :is-reviewed="evaluation.isReviewed"
+                :is-security-checkable="evaluation.isApplication && evaluation.consensus === 'pass'"
+                :is-security-checked="evaluation.isSecurityChecked"
+                :is-nat-or-trial-nat="loggedInUser.isNatOrTrialNat"
             />
 
             <card-footer

--- a/src/components/evaluations/info/DiscussionInfo.vue
+++ b/src/components/evaluations/info/DiscussionInfo.vue
@@ -17,6 +17,13 @@
                         loggedInUser.isNat
                     "
                 />
+                <evaluation-is-security-checked 
+                    v-if="
+                        loggedInUser.isNat && 
+                        selectedEvaluation.isApplication && 
+                        selectedEvaluation.consensus === 'pass'
+                    "
+                />
                 <evaluation-is-reviewed v-if="selectedEvaluation.feedback && loggedInUser.isNat" />
                 <evaluation-link v-if="selectedEvaluation.feedback" />
                 <feedback-info v-if="selectedEvaluation.consensus" />
@@ -46,6 +53,7 @@ import FeedbackInfo from './common/FeedbackInfo.vue';
 import evaluations from '../../../mixins/evaluations.js';
 import NextEvaluationEstimate from './common/NextEvaluationEstimate.vue';
 import EvaluationIsReviewed from './common/EvaluationIsReviewed.vue';
+import EvaluationIsSecurityChecked from './common/EvaluationIsSecurityChecked.vue';
 import EvaluationLink from './common/EvaluationLink.vue';
 
 export default {
@@ -57,6 +65,7 @@ export default {
         FeedbackInfo,
         NextEvaluationEstimate,
         EvaluationIsReviewed,
+        EvaluationIsSecurityChecked,
         EvaluationLink,
     },
     mixins: [evaluations],

--- a/src/components/evaluations/info/common/EvaluationIsSecurityChecked.vue
+++ b/src/components/evaluations/info/common/EvaluationIsSecurityChecked.vue
@@ -1,0 +1,45 @@
+<template>
+    <div>
+        <p>
+            <b>Security checked: </b>
+            <a
+                href="#"
+                data-toggle="tooltip"
+                data-placement="right"
+                title="@help in #gmt-help for a bn security check"
+                @click.prevent="toggleEvaluationIsSecurityChecked($event)"
+            >
+                <font-awesome-icon
+                    icon="fa-solid fa-circle-check"
+                    :class="selectedEvaluation.isSecurityChecked ? 'text-success' : 'text-secondary'"
+                />
+            </a>
+        </p>
+    </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+import evaluations from '../../../../mixins/evaluations.js';
+
+export default {
+    name: 'EvaluationIsSecurityChecked',
+    mixins: [evaluations],
+    computed: {
+        ...mapGetters('evaluations', ['selectedEvaluation']),
+    },
+    methods: {
+        async toggleEvaluationIsSecurityChecked(e) {
+            const result = await this.$http.executePost(`/${this.selectedEvaluation.isApplication ? 'appEval' : 'bnEval'}/toggleisSecurityChecked/${this.selectedEvaluation.id}`, e); 
+            
+            if (result && !result.error) {
+                this.$store.commit('evaluations/updateEvaluation', result);
+                this.$store.dispatch('updateToastMessages', {
+                    message: `Toggled security check status`,
+                    type: 'success',
+                });
+            }  
+        },
+    },
+}
+</script>

--- a/src/components/evaluations/info/common/FeedbackInfo.vue
+++ b/src/components/evaluations/info/common/FeedbackInfo.vue
@@ -47,6 +47,7 @@
             "
             :discord-link="discordLink"
             :is-reviewable="!selectedEvaluation.isResignation"
+            :is-security-checkable="selectedEvaluation.isApplication && selectedEvaluation.consensus === 'pass'"
         />
     </div>
 </template>

--- a/src/components/evaluations/info/common/FeedbackPm.vue
+++ b/src/components/evaluations/info/common/FeedbackPm.vue
@@ -9,6 +9,8 @@
             :custom-text="'Send message & archive'"
             :is-reviewable="isReviewable"
             :is-reviewed="selectedEvaluation.isReviewed"
+            :is-security-checkable="isSecurityCheckable"
+            :is-security-checked="selectedEvaluation.isSecurityChecked"
         />
     </div>
 </template>
@@ -30,6 +32,10 @@ export default {
             default: '',
         },
         isReviewable: {
+            type: Boolean,
+            default: false,
+        },
+        isSecurityCheckable: {
             type: Boolean,
             default: false,
         },

--- a/src/components/users/Badges.vue
+++ b/src/components/users/Badges.vue
@@ -113,16 +113,20 @@ export default {
 
             if (this.user) {
                 users = await this.$http.executeGet(`/users/nat/findUserBadgeInfo/` + this.user.id, e);
+
+                if (users) {
+                    this.badgeUsers = users;
+                }
             } else {
                 this.loading = true;
                 users = await this.$http.executeGet('/users/nat/findUserBadgeInfo/false', e);
                 this.loading = false;
-            }
 
-            if (users) {
-                this.badgeUsers = users.filter(user =>
-                    (this.yearsDuration(user.bnDuration) >= 1) || (this.yearsDuration(user.natDuration) >= 1 || user.actualNominationsProfileBadge >= 1)
-                );
+                if (users) {
+                    this.badgeUsers = users.filter(user =>
+                        (this.yearsDuration(user.bnDuration) >= 1) || (this.yearsDuration(user.natDuration) >= 1 || user.actualNominationsProfileBadge >= 1)
+                    );
+                }
             }
         },
         compareBadgeDuration (currentBadge, days) {


### PR DESCRIPTION
our red friends have been making one too many oopsies regarding this so i figured i'd make it a mandatory check for an eval, kinda like what we did with reviews

this adds a sec check toggle (and card icon) on applications that are supposed to be a pass only, it also hides the send eval button if not checked