### PR TITLE
serverside opengraph tags

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,9 @@ wsServer.on("connection", (socket, request) => {
     } is connected via websocket`);
 });
 
+// discord embeds
+app.use(middlewares.discordEmbeds);
+
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'hbs');

--- a/helpers/middlewares.js
+++ b/helpers/middlewares.js
@@ -105,6 +105,65 @@ async function isPishifat(req, res, next) {
     next();
 }
 
+function discordEmbeds(req, res, next) {
+    // skip if user is not a discord crawler
+    if (req.headers["user-agent"] !== "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)")
+        return next();
+
+    const routes = [
+        { path: '', title: 'BN Management' },
+        { path: 'home', title: 'BN Management' },
+        { path: 'bnapps', title: 'Beatmap Nominator Application' },
+        { path: 'testsubmission', title: 'Test Submission' },
+        { path: 'reports', title: 'Report Submission' },
+        { path: 'users', title: 'BN/NAT Listing' },
+        { path: 'vetoes', title: 'Vetoes' },
+        { path: 'qualityassurance', title: 'Quality Assurance' },
+        { path: 'testresults', title: 'Ranking Criteria Test Results' },
+        { path: 'yourevals', title: 'Your Evaluations' },
+        { path: 'message', title: 'Message from the NAT' },
+        { path: 'modrequests', title: 'Request a BN' },
+        { path: 'discussionvote', title: 'Content Review' },
+        { path: 'appeval', title: 'BN Application Evaluations' },
+        { path: 'bneval', title: 'Current BN Evaluations' },
+        { path: 'evalarchive', title: 'Evaluation Archives' },
+        { path: 'managereports', title: 'Manage Reports' },
+        { path: 'datacollection', title: 'Manage SEVs' },
+        { path: 'managetest', title: 'Manage RC Test' },
+        { path: 'logs', title: 'Logs' },
+        { path: 'spam', title: 'Spam' },
+    ];
+
+    const route = routes.find(r => r.path === req.path.substring(1));
+    const notFound = !route && req.path !== '/';
+
+    const title = !notFound ? route.title : 'not found :(';
+    const siteName = notFound || (route.path.length && route.path !== 'home') ? "BN Management" : "";
+    const url = `https://bn.mappersguild.com${req.path}`;
+    const description = `The place for everything related to the Beatmap Nominators${notFound ? ', not for whatever you were looking for.' : '!'}`
+
+    const html = `<html lang="en" prefix="og: https://ogp.me/ns#">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="icon" type="image/png" href="/images/qatlogo.png">
+
+      <meta property="og:title" content="${title}">
+      ${siteName.length ? `<meta property="og:site_name" content="${siteName}">` : ''}
+      <meta property="og:url" content="${url}">
+      <meta property="og:description" content="${description}">
+      <meta property="og:type" content="website">
+
+      <meta name="theme-color" content="#27b6b3">
+      <meta name="description" content="${description}">
+
+      <title>${title}</title>
+    </head>
+  </html>`;
+
+    res.status(notFound ? 404 : 200).send(html);
+}
+
 module.exports = {
     isLoggedIn,
     isBnOrNat,
@@ -116,4 +175,5 @@ module.exports = {
     hasFullReadAccess,
     hasPrivateInterOpsAccess,
     isPishifat,
+    discordEmbeds,
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -24,6 +24,10 @@ const ManageTest = () => import(/* webpackChunkName: "nat", webpackPrefetch: tru
 const Logs = () => import(/* webpackChunkName: "nat", webpackPrefetch: true */ './pages/Logs.vue');
 const Spam = () => import(/* webpackChunkName: "nat", webpackPrefetch: true */ './pages/Spam.vue');
 
+/**
+ * ! when adding/editing routes here, make sure you do the same adjustments in /helpers/middlewares.js (discordEmbeds)
+ */
+
 const routes = [
     // Public
     { path: '/', component: Home, alias: '/home', name: 'home', meta: { public: true } },

--- a/views/error.hbs
+++ b/views/error.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html prefix="og: https://ogp.me/ns#">
+<html lang="en" prefix="og: https://ogp.me/ns#">
 
 <head>
     <meta charset="utf-8" />

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html prefix="og: https://ogp.me/ns#">
+<html lang="en" prefix="og: https://ogp.me/ns#">
 
 <head>
     <meta charset="utf-8" />
@@ -8,12 +8,6 @@
 
     <title>BN Management</title>
     <meta name="keywords" content="beatmap nominators, nomination assesment team, nat, bn, osu">
-
-    <meta property="og:title" content="BN Management" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://bn.mappersguild.com/" />
-    <meta property="og:description" content="The place for everything related to the Beatmap Nominators!" />
-
     <meta name="theme-color" content="#27b6b3" />
     <meta name="description" content="The place for everything related to the Beatmap Nominators!" />
 


### PR DESCRIPTION
okso i did a very good amount of research and testing for this, i'll explain why this one will definitely work and is not loads of copium:

the way discord embeds work is crawlers making a GET request to the server route, and since everything is rendered client side it means the crawler only gets [`index.hbs`](https://github.com/pishifat/qat/blob/master/views/index.hbs) because that's the only thing rendered by the server by default.

ive noticed that other CSR projects handle this by sending a dedicated serverside response to discord crawlers, and use normal CSR for everything else ([example](https://github.com/Sebola3461/osumodhub/blob/master/server/middlewares/DiscordEmbed.ts)). so i turned the opengraph stuff into a middleware that's only executed if the useragent matches the discord bot's one. i also did some extensive testing on this by spoofing my useragent and it works as expected, while keeping the site working as normal for every other useragent.

this also makes it pretty easy to implement more variables to the embeds by having some db action in the middleware depending on the route. i can look into this later once we figure out what kind of variables we want to expose publicly.

