### PR TITLE
disable type checking in `.js` files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "allowJs": true,
-        "checkJs": true,
+        "checkJs": false,
         "resolveJsonModule": true,
         "noEmit": true,
         "esModuleInterop": true,


### PR DESCRIPTION
all this did is spam a shitload of false positives whenever `req.session` is used in backend, and is likely the cause of a bunch of other false positives in frontend js

feel free to close if this is actually useful in a way i didnt notice