### PR TITLE
add ability to view and toggle eval visibility

### DIFF
--- a/models/evaluations/appEvaluation.js
+++ b/models/evaluations/appEvaluation.js
@@ -11,7 +11,7 @@ const appEvaluationSchema = new mongoose.Schema({
     natBuddy: { type: 'ObjectId', ref: 'User' },
     vibeChecks: [{ type: 'ObjectId', ref: 'Mediation' }],
     comment: { type: String },
-    visibleToPublic: { type: Boolean },
+    isPublic: { type: Boolean },
 }, { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } });
 
 class AppEvaluationService extends mongoose.Model {

--- a/models/interfaces/evaluations.ts
+++ b/models/interfaces/evaluations.ts
@@ -34,6 +34,8 @@ export interface IAppEvaluationDocument extends IEvaluationBase, Document {
     deadline?: Date;
     kind?: string;
     natBuddy?: IUserDocument;
+    comment?: string;
+    isPublic?: boolean;
 }
 
 export interface IAppEvaluationModel extends Model<IAppEvaluationDocument> {

--- a/routes/evaluations/appEval.js
+++ b/routes/evaluations/appEval.js
@@ -793,4 +793,25 @@ router.post('/deleteReview/:id', middlewares.isResponsibleWithButtons, async (re
     );
 });
 
+/* POST toggle visibility */
+router.post('/toggleVisibility/:id', middlewares.isNat, async (req, res) => {
+    const app = await AppEvaluation
+        .findById(req.params.id)
+        .populate(defaultPopulate);
+
+    console.log(app.isPublic);
+
+    app.isPublic = req.body.isPublic;
+    await app.save();
+
+    res.json(app);
+
+    Logger.generate(
+        req.session.mongoId,
+        `Changed visibility  of ${app.user.username}'s ${app.mode} BN app to "${app.isPublic ? 'public' : 'private'}"`,
+        'appEvaluation',
+        app._id
+    );
+});
+
 module.exports = router;

--- a/src/components/evaluations/card/CardHeader.vue
+++ b/src/components/evaluations/card/CardHeader.vue
@@ -34,6 +34,13 @@
                 class="fas fa-user mr-1"
                 :class="hasNatBuddy ? '' : 'text-warning'"
             />
+            <i
+                v-if="!isActive && isApplication && isPublic"
+                data-toggle="tooltip"
+                data-placement="top"
+                title="visible in public archives"
+                class="fas fa-globe-americas mr-1 text-success"
+            />
         </p>
         <div v-if="consensus">
             Consensus:
@@ -112,6 +119,18 @@ export default {
         hasNatBuddy: {
             type: Boolean,
             default: false,
+        },
+        isApplication: {
+            type: Boolean,
+            default: false,
+        },
+        isPublic: {
+            type: Boolean,
+            default: false,
+        },
+        isActive: {
+            type: Boolean,
+            default: true,
         },
     },
 };

--- a/src/components/evaluations/card/EvaluationCard.vue
+++ b/src/components/evaluations/card/EvaluationCard.vue
@@ -24,6 +24,9 @@
                 :is-discussion="evaluation.discussion"
                 :is-resignation="evaluation.kind == 'resignation'"
                 :is-nat-evaluation="evaluation.selfSummary"
+                :is-application="evaluation.isApplication"
+                :is-public="evaluation.isPublic"
+                :is-active="evaluation.active"
             />
 
             <card-footer

--- a/src/components/evaluations/info/applications/ApplicantComment.vue
+++ b/src/components/evaluations/info/applications/ApplicantComment.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mb-2">
         <b>Comment:</b>
-        <span class="text-secondary">{{ comment }}</span>
+        <span class="text-secondary">{{ comment || 'None...' }}</span>
     </div>
 </template>
 

--- a/src/components/evaluations/info/applications/EvaluationVisibility.vue
+++ b/src/components/evaluations/info/applications/EvaluationVisibility.vue
@@ -1,0 +1,53 @@
+<template>
+    <div>
+        <p>
+            <b>Visibility:</b>
+            <span :class="selectedEvaluation.isPublic ? 'text-success' : 'text-danger'">
+                {{ selectedEvaluation.isPublic ? 'Public' : 'Private' }}
+            </span>
+            <span v-if="loggedInUser.id === selectedEvaluation.user.id" class="btn-group ml-2">
+                <button
+                    class="btn btn-sm btn-success"
+                    :disabled="selectedEvaluation.isPublic"
+                    @click="toggleVisibility(true, $event);"
+                >
+                    Public
+                </button>
+                <button
+                    class="btn btn-sm btn-danger"
+                    :disabled="!selectedEvaluation.isPublic"
+                    @click="toggleVisibility(false, $event);"
+                >
+                    Private
+                </button>
+            </span>
+        </p>
+    </div>
+</template>
+
+<script>
+import { mapState, mapGetters } from 'vuex';
+
+export default {
+    name: 'EvaluationVisibility',
+    computed: {
+        ...mapState(['loggedInUser']),
+        ...mapGetters('evaluations', ['selectedEvaluation']),
+    },
+    methods: {
+        async toggleVisibility(isPublic, e) {
+            const res = await this.$http.executePost(`/appEval/toggleVisibility/${this.selectedEvaluation.id}`, {
+                isPublic,
+            });
+
+            if (this.$http.isValid(res)) {
+                this.$store.commit('evaluations/updateEvaluation', res);
+                this.$store.dispatch('updateToastMessages', {
+                    message: `Set visibility to ${isPublic ? 'public' : 'private'}`,
+                    type: 'success',
+                });
+            }
+        },
+    },      
+}; 
+</script>

--- a/src/components/evaluations/info/applications/MainApplicationInfo.vue
+++ b/src/components/evaluations/info/applications/MainApplicationInfo.vue
@@ -10,6 +10,8 @@
         <applicant-comment
             :comment="selectedEvaluation.comment"
         />
+
+        <evaluation-visibility />
     </div>
 </template>
 
@@ -17,14 +19,14 @@
 import { mapState, mapGetters } from 'vuex';
 import Mods from './Mods.vue';
 import ApplicantComment from './ApplicantComment.vue';
-import EvaluationLink from '../common/EvaluationLink.vue';
+import EvaluationVisibility from './EvaluationVisibility.vue';
 
 export default {
     name: 'MainApplicationInfo',
     components: {
         Mods,
         ApplicantComment,
-        EvaluationLink,
+        EvaluationVisibility,
     },
     computed: {
         ...mapState([


### PR DESCRIPTION
only thing that's left is the actual page

your view
![image](https://github.com/pishifat/qat/assets/62819481/7d54c27b-e13e-4704-81e9-d28ac44fedee)

other view
![image](https://github.com/pishifat/qat/assets/62819481/b52e4577-264b-4d6f-9a84-dfc9edfcdc74)

public cards
![image](https://github.com/pishifat/qat/assets/62819481/eeadb4fb-57c0-4c70-8410-18597c413955)
