### PR TITLE
public evals pagination

### DIFF
--- a/routes/users/users.js
+++ b/routes/users/users.js
@@ -1233,8 +1233,6 @@ router.post('/toggleEvalVisibility/:id', async (req, res) => {
         });
     }
 
-    console.log(eval);
-
     //check eval ownership
     if (req.session.mongoId != eval.user.id) {
         return res.json({

--- a/src/components/PaginationNav.vue
+++ b/src/components/PaginationNav.vue
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-6 text-right">
             <button
-                v-if="pagination.page > 1"
+                v-if="page > 1"
                 class="btn btn-lg btn-link"
                 type="button"
                 @click="decreasePage"
@@ -13,7 +13,7 @@
 
         <div class="col-6">
             <button
-                v-if="pagination.page < pagination.maxPages"
+                v-if="page < maxPages"
                 class="btn btn-lg btn-link"
                 type="button"
                 @click="increasePage"
@@ -32,18 +32,47 @@ export default {
             type: String,
             required: true,
         },
+        type: String,
     },
     computed: {
         pagination () {
-            return this.$store.state[this.storeModule].pagination;
+            return this.type ? this.$store.state[this.storeModule].evalPagination : this.$store.state[this.storeModule].pagination;
+        },
+        page () {
+            return this.type === 'applications' ? 
+                this.pagination.archivedAppsPage :
+                this.type === 'evaluations' ? 
+                    this.pagination.archivedCurrentBnEvalsPage :
+                    this.pagination.page;
+        },
+        maxPages () {
+            return this.type === 'applications' ? 
+                this.pagination.archivedAppsMaxPages : 
+                this.type === 'evaluations' ?
+                    this.pagination.archivedCurrentBnEvalsMaxPages :
+                    this.pagination.maxPages;
         },
     },
     methods: {
         increasePage () {
-            this.$store.commit(this.storeModule + '/pagination/increasePage');
+            const mutation = 
+                this.type === 'applications' ? 
+                    '/evalPagination/increaseArchivedAppsPage' :
+                    this.type === 'evaluations' ?
+                        '/evalPagination/increaseArchivedCurrentBnEvalsPage' :
+                        '/pagination/increasePage';
+
+            this.$store.commit(this.storeModule + mutation);
         },
         decreasePage () {
-            this.$store.commit(this.storeModule + '/pagination/decreasePage');
+            const mutation = 
+                this.type === 'applications' ? 
+                    '/evalPagination/decreaseArchivedAppsPage' :
+                    this.type === 'evaluations' ?
+                        '/evalPagination/decreaseArchivedCurrentBnEvalsPage' :
+                        '/pagination/decreasePage';
+
+            this.$store.commit(this.storeModule + mutation);
         },
     },
 };

--- a/src/components/evaluations/info/PublicEvalsInfo.vue
+++ b/src/components/evaluations/info/PublicEvalsInfo.vue
@@ -29,7 +29,7 @@
                 :is-nat="selectedEvaluation.user.isNat"
             />
 
-            <evaluation-visibility v-if="!selectedEvaluation.isApplication && !isNatEvaluation" />
+            <evaluation-visibility v-if="selectedEvaluation.kind ==='currentBn' && !isNatEvaluation" />
 
             <evaluation-link />
 

--- a/src/pages/DiscussionVotePage.vue
+++ b/src/pages/DiscussionVotePage.vue
@@ -149,8 +149,8 @@ export default {
     },
     data() {
         return {
-            skip: 20,
-            limit: 20,
+            skip: 24,
+            limit: 24,
             reachedMax: false,
             tempShowExplicitContent: false,
             isContentReview: true,

--- a/src/pages/PublicEvalArchivePage.vue
+++ b/src/pages/PublicEvalArchivePage.vue
@@ -8,6 +8,60 @@
                 :groups="null"
                 store-module="evaluations"
             >
+            <div class="mt-2 ml-1">
+                Consensus:
+                <div class="ml-2 btn-group">
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-info ml-2"
+                        @click="applyConsensusFilter(null)"
+                        :disabled="consensusFilter === null"
+                    >
+                        Any
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-success"
+                        @click="applyConsensusFilter('pass')"
+                        :disabled="consensusFilter === 'pass'"
+                    >
+                        Pass
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-danger"
+                        @click="applyConsensusFilter('fail')"
+                        :disabled="consensusFilter === 'fail'"
+                    >
+                        Fail
+                    </button>
+                
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-bn"
+                        @click="applyConsensusFilter('fullBn')"
+                        :disabled="consensusFilter === 'fullBn'"
+                    >
+                        Full BN
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-probation"
+                        @click="applyConsensusFilter('probationBn')"
+                        :disabled="consensusFilter === 'probationBn'"
+                    >
+                        Probation BN
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-danger"
+                        @click="applyConsensusFilter('removeFromBn')"
+                        :disabled="consensusFilter === 'removeFromBn'"
+                    >
+                        Remove From BN
+                    </button>
+                 </div>
+            </div>
             <div v-if="!reachedMax" class="mt-2">
                 <button
                     type="button"
@@ -30,46 +84,16 @@
                 <h2>
                     Application Evaluations
                     <small v-if="archivedApplications">
-                        ({{ filterEvals(archivedApplications, appConsensusFilter).length + (reachedMax ? '' : '+')}})
+                        ({{ filterEvals(archivedApplications, consensusFilter).length + (reachedMax ? '' : '+')}})
                     </small>
                 </h2>
-                <div class="mt-2">
-                    Consensus:
-                        <div class="ml-2 btn-group">
-                            <button
-                                type="button"
-                                class="btn btn-sm btn-info ml-2"
-                                @click="appConsensusFilter = null"
-                                :disabled="appConsensusFilter === null"
-                            >
-                                Any
-                            </button>
-                            <button
-                                type="button"
-                                class="btn btn-sm btn-success"
-                                @click="appConsensusFilter = 'pass'"
-                                :disabled="appConsensusFilter === 'pass'"
-                            >
-                                Pass
-                            </button>
-                            <button
-                                type="button"
-                                class="btn btn-sm btn-danger"
-                                @click="appConsensusFilter = 'fail'"
-                                :disabled="appConsensusFilter === 'fail'"
-                            >
-                                Fail
-                            </button>
-                        </div>
-                    </div>
-                <hr>
-                <span v-if="!filterEvals(archivedApplications, appConsensusFilter).length" class="ml-4">
+                <span v-if="!filterEvals(archivedApplications, consensusFilter).length" class="ml-4">
                     None...
                 </span>
                 <transition-group name="list" tag="div" class="row">
                     <evaluation-card
-                        v-if="filterEvals(archivedApplications, appConsensusFilter)"
-                        v-for="application in filterEvals(archivedApplications, appConsensusFilter)"
+                        v-if="filterEvals(paginatedArchivedApplications, consensusFilter)"
+                        v-for="application in filterEvals(paginatedArchivedApplications, consensusFilter)"
                         :key="application._id"
                         :evaluation="application"
                         store-module="evaluations"
@@ -79,83 +103,30 @@
                         None...
                     </span>
                 </transition-group>
-                
+                <pagination-nav store-module="evaluations" type="applications" />
             </section>
 
             <section class="card card-body">
                 <h2>
                     BN Evaluations
                     <small v-if="archivedCurrentBnEvals">
-                        ({{ filterEvals(archivedCurrentBnEvals, bnEvalConsensusFilter).length + (reachedMax ? '' : '+')}})
+                        ({{ filterEvals(archivedCurrentBnEvals, consensusFilter).length + (reachedMax ? '' : '+')}})
                     </small>
                 </h2>
-                <div class="mt-2">
-                    Consensus:
-                    <div class="ml-2 btn-group">
-                        <button
-                            type="button"
-                            class="btn btn-sm btn-info ml-2"
-                            @click="bnEvalConsensusFilter = null"
-                            :disabled="bnEvalConsensusFilter === null"
-                        >
-                            Any
-                        </button>
-                        <button
-                            type="button"
-                            class="btn btn-sm btn-success"
-                            @click="bnEvalConsensusFilter = 'fullBn'"
-                            :disabled="bnEvalConsensusFilter === 'fullBn'"
-                        >
-                            Full BN
-                        </button>
-                        <button
-                            type="button"
-                            class="btn btn-sm btn-probation"
-                            @click="bnEvalConsensusFilter = 'probationBn'"
-                            :disabled="bnEvalConsensusFilter === 'probationBn'"
-                        >
-                            Probation BN
-                        </button>
-                        <button
-                            type="button"
-                            class="btn btn-sm btn-danger"
-                            @click="bnEvalConsensusFilter = 'removeFromBn'"
-                            :disabled="bnEvalConsensusFilter === 'removeFromBn'"
-                        >
-                            Remove From BN
-                        </button>
-                        <button
-                            type="button"
-                            class="btn btn-sm btn-secondary"
-                            @click="bnEvalConsensusFilter = 'resignedOnGoodTerms'"
-                            :disabled="bnEvalConsensusFilter === 'resignedOnGoodTerms'"
-                        >
-                            Resigned on Good Terms
-                        </button>
-                        <button
-                            type="button"
-                            class="btn btn-sm btn-primary"
-                            @click="bnEvalConsensusFilter = 'resignedOnStandardTerms'"
-                            :disabled="bnEvalConsensusFilter === 'resignedOnStandardTerms'"
-                        >
-                            Resigned on Standard Terms
-                        </button>
-                    </div>
-                </div>
-                <hr>
-                <span v-if="!filterEvals(archivedCurrentBnEvals, bnEvalConsensusFilter).length" class="ml-4">
+                <span v-if="!filterEvals(archivedCurrentBnEvals, consensusFilter).length" class="ml-4">
                     None...
                 </span>
                 <transition-group name="list"tag="div"class="row">
                     <evaluation-card
-                        v-if="filterEvals(archivedCurrentBnEvals, bnEvalConsensusFilter).length"
-                        v-for="evaluation in filterEvals(archivedCurrentBnEvals, bnEvalConsensusFilter)"
+                        v-if="filterEvals(paginatedArchivedCurrentBnEvals, consensusFilter).length"
+                        v-for="evaluation in filterEvals(paginatedArchivedCurrentBnEvals, consensusFilter)"
                         :key="evaluation._id"
                         :evaluation="evaluation"
                         store-module="evaluations"
                         target="#extendedInfo"
                     />
                 </transition-group>
+                <pagination-nav store-module="evaluations" type="evaluations" />
             </section>
 
             <public-evals-info />
@@ -171,6 +142,7 @@ import ToastMessages from '../components/ToastMessages.vue';
 import EvaluationCard from '../components/evaluations/card/EvaluationCard.vue';
 import PublicEvalsInfo from '../components/evaluations/info/PublicEvalsInfo.vue';
 import FilterBox from '../components/FilterBox.vue';
+import PaginationNav from '../components/PaginationNav.vue';
 
 export default {
     name: 'PublicEvalArchivePage',
@@ -179,14 +151,14 @@ export default {
         EvaluationCard,
         PublicEvalsInfo,
         FilterBox,
+        PaginationNav,
     },
     data() {
         return {
             skip: 24,
             limit: 24,
             reachedMax: false,
-            appConsensusFilter: null,
-            bnEvalConsensusFilter: null,
+            consensusFilter: null,
         };
     },
     computed: {
@@ -197,7 +169,17 @@ export default {
             'selectedEvaluation',
             'archivedApplications',
             'archivedCurrentBnEvals',
+            'paginatedArchivedApplications',
+            'paginatedArchivedCurrentBnEvals',
         ]),
+    },
+    watch: {
+        archivedApplications(v) {
+            this.$store.dispatch('evaluations/evalPagination/updateArchivedAppsMaxPages', v.length);
+        },
+        archivedCurrentBnEvals(v) {
+            this.$store.dispatch('evaluations/evalPagination/updateArchivedCurrentBnEvalsMaxPages', v.length);
+        },
     },
     beforeCreate() {
         if (this.$store.hasModule('evaluations')) {
@@ -275,7 +257,10 @@ export default {
             if (consensus === null) return evals;
             return evals.filter(e => e.consensus === consensus);
         },
+        applyConsensusFilter(consensus) {
+            this.consensusFilter = consensus;
+            this.$store.commit('evaluations/pageFilters/setFilterConsensus', consensus);
+        }
     },
 };
-
 </script>

--- a/src/pages/PublicEvalArchivePage.vue
+++ b/src/pages/PublicEvalArchivePage.vue
@@ -91,14 +91,16 @@
                     None...
                 </span>
                 <transition-group name="list" tag="div" class="row">
-                    <evaluation-card
-                        v-if="filterEvals(paginatedArchivedApplications, consensusFilter)"
-                        v-for="application in filterEvals(paginatedArchivedApplications, consensusFilter)"
-                        :key="application._id"
-                        :evaluation="application"
-                        store-module="evaluations"
-                        target="#extendedInfo"
-                    />
+                    <template v-if="filterEvals(paginatedArchivedApplications, consensusFilter)">
+                        <evaluation-card
+                            
+                            v-for="application in filterEvals(paginatedArchivedApplications, consensusFilter)"
+                            :key="application._id"
+                            :evaluation="application"
+                            store-module="evaluations"
+                            target="#extendedInfo"
+                        />
+                    </template>
                     <span v-else class="small">
                         None...
                     </span>
@@ -116,15 +118,19 @@
                 <span v-if="!filterEvals(archivedCurrentBnEvals, consensusFilter).length" class="ml-4">
                     None...
                 </span>
-                <transition-group name="list"tag="div"class="row">
-                    <evaluation-card
-                        v-if="filterEvals(paginatedArchivedCurrentBnEvals, consensusFilter).length"
-                        v-for="evaluation in filterEvals(paginatedArchivedCurrentBnEvals, consensusFilter)"
-                        :key="evaluation._id"
-                        :evaluation="evaluation"
-                        store-module="evaluations"
-                        target="#extendedInfo"
-                    />
+                <transition-group name="list" tag="div" class="row">
+                    <template v-if="filterEvals(paginatedArchivedCurrentBnEvals, consensusFilter).length">
+                        <evaluation-card
+                            v-for="evaluation in filterEvals(paginatedArchivedCurrentBnEvals, consensusFilter)"
+                            :key="evaluation._id"
+                            :evaluation="evaluation"
+                            store-module="evaluations"
+                            target="#extendedInfo"
+                        />
+                    </template>
+                    <span v-else class="small">
+                        None...
+                    </span>
                 </transition-group>
                 <pagination-nav store-module="evaluations" type="evaluations" />
             </section>
@@ -155,8 +161,8 @@ export default {
     },
     data() {
         return {
-            skip: 24,
-            limit: 24,
+            skip: 48,
+            limit: 48,
             reachedMax: false,
             consensusFilter: null,
         };

--- a/src/pages/VetoesPage.vue
+++ b/src/pages/VetoesPage.vue
@@ -98,8 +98,8 @@ export default {
     },
     data() {
         return {
-            skip: 20,
-            limit: 20,
+            skip: 24,
+            limit: 24,
             reachedMax: false,
         };
     },

--- a/src/store/evaluations.js
+++ b/src/store/evaluations.js
@@ -1,10 +1,12 @@
 import Vue from 'vue';
 import pageFilters from './modules/pageFilters';
+import evalPagination from './modules/evalPagination';
 
 export default {
     namespaced: true,
     modules: {
         pageFilters,
+        evalPagination,
     },
     state: () => ({
         evaluations: [],
@@ -58,6 +60,7 @@ export default {
             const mode = rootState.evaluations.pageFilters.filters.mode;
             const group = rootState.evaluations.pageFilters.filters.group;
             const value = rootState.evaluations.pageFilters.filters.value;
+            const consensus = rootState.evaluations.pageFilters.filters.consensus;
 
             if (mode) {
                 evaluations = evaluations.filter(a => a.mode == mode);
@@ -72,6 +75,12 @@ export default {
             if (value) {
                 evaluations = evaluations.filter(a =>
                     a.user.username.toLowerCase().includes(value.toLowerCase())
+                );
+            }
+
+            if (consensus) {
+                evaluations = evaluations.filter(a =>
+                    a.consensus == consensus
                 );
             }
 
@@ -91,6 +100,24 @@ export default {
         },
         selectedEvaluation: (state) => {
             return state.evaluations.find(e => e.id === state.selectedEvaluationId);
+        },
+        paginatedArchivedApplications: (state, getters, rootState) => {
+            const limit = rootState.evaluations.evalPagination.limit;
+            const page = rootState.evaluations.evalPagination.archivedAppsPage;
+
+            return getters.archivedApplications.slice(
+                limit * (page - 1),
+                limit * page
+            );
+        },
+        paginatedArchivedCurrentBnEvals: (state, getters, rootState) => {
+            const limit = rootState.evaluations.evalPagination.limit;
+            const page = rootState.evaluations.evalPagination.archivedCurrentBnEvalsPage;
+
+            return getters.archivedCurrentBnEvals.slice(
+                limit * (page - 1),
+                limit * page
+            );
         },
     },
 };

--- a/src/store/modules/evalPagination.js
+++ b/src/store/modules/evalPagination.js
@@ -1,0 +1,51 @@
+export default {
+    namespaced: true,
+    state: () => ({
+        limit: 24,
+        archivedAppsPage: 1,
+        archivedAppsMaxPages: 1,
+        archivedCurrentBnEvalsPage: 1,
+        archivedCurrentBnEvalsMaxPages: 1,
+    }),
+    mutations: {
+        resetPagination (state) {
+            state.archivedAppsPage = 1;
+            state.archivedCurrentBnEvalsPage = 1;
+        },
+        /* archived apps pagination */
+        increaseArchivedAppsPage (state) {
+            state.archivedAppsPage += 1;
+        },
+        decreaseArchivedAppsPage (state) {
+            state.archivedAppsPage -= 1;
+        },
+        updateArchivedAppsMaxPages (state, maxPages) {
+            state.archivedAppsMaxPages = maxPages;
+        },
+        /* archived bn evals pagination */
+        increaseArchivedCurrentBnEvalsPage (state) {
+            state.archivedCurrentBnEvalsPage += 1;
+        },
+        decreaseArchivedCurrentBnEvalsPage (state) {
+            state.archivedCurrentBnEvalsPage -= 1;
+        },
+        updateArchivedCurrentBnEvalsMaxPages (state, maxPages) {
+            state.archivedCurrentBnEvalsMaxPages = maxPages;
+        },
+    },
+    actions: {
+        updateArchivedAppsMaxPages ({ state, commit }, length) {
+            const maxPages = Math.ceil(length / state.limit);
+
+            commit('resetPagination');
+            commit('updateArchivedAppsMaxPages', maxPages);
+        },
+
+        updateArchivedCurrentBnEvalsMaxPages ({ state, commit }, length) {
+            const maxPages = Math.ceil(length / state.limit);
+
+            commit('resetPagination');
+            commit('updateArchivedCurrentBnEvalsMaxPages', maxPages);
+        },
+    },
+};

--- a/src/store/modules/evalPagination.js
+++ b/src/store/modules/evalPagination.js
@@ -1,7 +1,7 @@
 export default {
     namespaced: true,
     state: () => ({
-        limit: 24,
+        limit: 12,
         archivedAppsPage: 1,
         archivedAppsMaxPages: 1,
         archivedCurrentBnEvalsPage: 1,

--- a/src/store/modules/pageFilters.js
+++ b/src/store/modules/pageFilters.js
@@ -5,6 +5,7 @@ export default {
             mode: '',
             value: '',
             group: '',
+            consensus: null,
         },
     }),
     mutations: {
@@ -16,6 +17,9 @@ export default {
         },
         setFilterGroup (state, group) {
             state.filters.group = group;
+        },
+        setFilterConsensus (state, consensus) {
+            state.filters.consensus = consensus;
         },
         resetFilters (state) {
             state.filters.mode = '';

--- a/src/store/modules/pagination.js
+++ b/src/store/modules/pagination.js
@@ -2,7 +2,7 @@ export default {
     namespaced: true,
     state: () => ({
         page: 1,
-        limit: 24,
+        limit: 12,
         maxPages: 1,
     }),
     mutations: {


### PR DESCRIPTION
`src/components/PaginationNav.vue` could maybe use some cleanup later/split into 2 component versions?

u may wonder why i had to unify consensus filter between apps and evals and thats because unfortunately fuck vue state (only way to apply filter while keeping pagination working and updating as intended)